### PR TITLE
Use string session keys in the CSRFProtection plug

### DIFF
--- a/lib/plug/csrf_protection.ex
+++ b/lib/plug/csrf_protection.ex
@@ -48,7 +48,7 @@ defmodule Plug.CSRFProtection do
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    csrf_token = get_session(conn, :csrf_token)
+    csrf_token = get_session(conn, "csrf_token")
 
     if not verified_request?(conn, csrf_token) do
       raise InvalidCSRFTokenError
@@ -105,7 +105,7 @@ defmodule Plug.CSRFProtection do
     if csrf_token do
       conn
     else
-      put_session(conn, :csrf_token, generate_token())
+      put_session(conn, "csrf_token", generate_token())
     end
   end
 

--- a/test/plug/csrf_protection_test.exs
+++ b/test/plug/csrf_protection_test.exs
@@ -65,16 +65,16 @@ defmodule Plug.CSRFProtectionTest do
   test "unprotected requests are always valid" do
     conn = conn(:get, "/") |> call()
     assert conn.halted == false
-    assert get_session(conn, :csrf_token)
+    assert get_session(conn, "csrf_token")
 
     conn = conn(:head, "/") |> call()
     assert conn.halted == false
-    assert get_session(conn, :csrf_token)
+    assert get_session(conn, "csrf_token")
   end
 
   test "protected requests with valid token in params are allowed" do
     old_conn = conn(:get, "/") |> call
-    params = %{csrf_token: get_session(old_conn, :csrf_token)}
+    params = %{csrf_token: get_session(old_conn, "csrf_token")}
 
     conn = conn(:post, "/", params) |> call(old_conn)
     assert conn.halted == false
@@ -88,7 +88,7 @@ defmodule Plug.CSRFProtectionTest do
 
   test "protected requests with valid token in header are allowed" do
     old_conn = conn(:get, "/") |> call
-    csrf_token = get_session(old_conn, :csrf_token)
+    csrf_token = get_session(old_conn, "csrf_token")
 
     conn =
       conn(:post, "/")
@@ -125,7 +125,7 @@ defmodule Plug.CSRFProtectionTest do
       |> assign(:content_type, "text/javascript")
       |> put_req_header("x-requested-with", "XMLHttpRequest")
       |> call()
-    assert get_session(conn, :csrf_token)
+    assert get_session(conn, "csrf_token")
   end
 
   test "csrf plug is skipped when plug_skip_csrf_protection is true" do
@@ -133,19 +133,19 @@ defmodule Plug.CSRFProtectionTest do
       conn(:get, "/")
       |> put_private(:plug_skip_csrf_protection, true)
       |> call()
-    assert get_session(conn, :csrf_token)
+    assert get_session(conn, "csrf_token")
 
     conn =
       conn(:post, "/", %{})
       |> put_private(:plug_skip_csrf_protection, true)
       |> call()
-    assert get_session(conn, :csrf_token)
+    assert get_session(conn, "csrf_token")
 
     conn =
       conn(:get, "/")
       |> put_private(:plug_skip_csrf_protection, true)
       |> assign(:content_type, "text/javascript")
       |> call()
-    assert get_session(conn, :csrf_token)
+    assert get_session(conn, "csrf_token")
   end
 end


### PR DESCRIPTION
Addresses #167 

The rationale behind this change is that other than erlang binary term
session serializers can be used (such as JSON serializers) and since
atom is not a very universal type, a string is suggested.