### PR TITLE
Add more docs info in the mix.exs' project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /_build
 /deps
 /docs
+/doc
 erl_crash.dump
 *.ez

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,8 @@ defmodule Plug.Mixfile do
      package: package,
      description: "A specification and conveniences for composable " <>
                   "modules in between web applications",
-     docs: [readme: true, main: "README",
+     name: "Plug",
+     docs: [readme: "README.md", main: "README",
             source_ref: "v#{@version}",
             source_url: "https://github.com/elixir-lang/plug"]]
   end
@@ -25,7 +26,7 @@ defmodule Plug.Mixfile do
   def deps do
     [{:cowboy, "~> 1.0", optional: true},
      {:earmark, "~> 0.1", only: :docs},
-     {:ex_doc, "~> 0.6", only: :docs},
+     {:ex_doc, "~> 0.7", only: :docs},
      {:inch_ex, only: :docs},
      {:hackney, "~> 0.13", only: :test}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"cowboy": {:hex, :cowboy, "1.0.0"},
   "cowlib": {:hex, :cowlib, "1.0.0"},
   "earmark": {:hex, :earmark, "0.1.10"},
-  "ex_doc": {:hex, :ex_doc, "0.6.0"},
+  "ex_doc": {:hex, :ex_doc, "0.7.0"},
   "hackney": {:hex, :hackney, "0.13.1"},
   "idna": {:hex, :idna, "1.0.1"},
   "inch_ex": {:hex, :inch_ex, "0.2.1"},


### PR DESCRIPTION
I added the `:name` option and removed old options from the `:docs` key. I'm not even sure that `:readme` and `:main` were still valid options. Anyways, I took these options from the ex_doc readme so they should be fine.

**PS** the main reason for this PR is that the top left `plug v0.10.0` title on http://hexdocs.pm/plug/ was not a link to https://github.com/elixir-lang/plug, and it's useful when it is! I also think that the docs for Plug were missing the "Source" links because of this issue.