### PR TITLE
Docs and code microfixes in Plug.Static 

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -97,7 +97,7 @@ defmodule Plug.Static do
         {_, _} -> from
         _ when is_atom(from) -> {from, "priv/static"}
         _ when is_binary(from) -> from
-        _ -> raise ArgumentError, ":from must be an atom or a binary"
+        _ -> raise ArgumentError, ":from must be an atom, a binary or a tuple"
       end
 
     {Plug.Router.Utils.split(at), from, gzip, qs_cache, et_cache, only}

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -39,19 +39,19 @@ defmodule Plug.Static do
   ## Options
 
     * `:gzip` - given a request for `FILE`, serves `FILE.gz` if it exists
-      in the static directory and if the `accept-encoding` ehader is set
-      to allow gzipped content (defaults to `false`)
+      in the static directory and if the `accept-encoding` header is set
+      to allow gzipped content (defaults to `false`).
 
     * `:cache_control_for_etags` - sets cache header for requests
-      that use etags. Defaults to "public".
+      that use etags. Defaults to `"public"`.
 
     * `:cache_control_for_vsn_requests` - sets cache header for requests
       starting with "?vsn=" in the query string. Defaults to
-      "public, max-age=31536000"
+      `"public, max-age=31536000"`.
 
-    * `:only` - filter which paths to lookup. This is useful to avoid
-      file system traversals on every request when the plug is mounted
-      at "/"
+    * `:only` - filters which paths to lookup. This is useful to avoid
+      file system traversals on every request when this plug is mounted
+      at `"/"`. Defaults to `nil` (no filtering).
 
   ## Examples
 
@@ -64,7 +64,7 @@ defmodule Plug.Static do
         plug :not_found
 
         def not_found(conn, _) do
-          Plug.Conn.send_resp(conn, 404, "not found")
+          send_resp(conn, 404, "not found")
         end
       end
 
@@ -207,9 +207,9 @@ defmodule Plug.Static do
   end
 
   defp path({app, from}, segments) when is_atom(app) and is_binary(from),
-    do: Path.join([Application.app_dir(app), from | segments])
+    do: Path.join([Application.app_dir(app), from|segments])
   defp path(from, segments),
-    do: Path.join([from | segments])
+    do: Path.join([from|segments])
 
   defp subset([h|expected], [h|actual]),
     do: subset(expected, actual)

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -76,6 +76,12 @@ defmodule Plug.Static do
   import Plug.Conn
   alias Plug.Conn
 
+  # In this module, the `:prim_info` Erlang module along with the `:file_info`
+  # record are used instead of the more common and Elixir-y `File` module and
+  # `File.Stat` struct, respectively. The reason behind this is performance: all
+  # the `File` operations pass through a single process in order to support node
+  # operations that we simply don't need when serving assets.
+
   require Record
   Record.defrecordp :file_info, Record.extract(:file_info, from_lib: "kernel/include/file.hrl")
 


### PR DESCRIPTION
- Polish the module documentation (mainly formatting)
- Update an error message
- Ditch the `file_info` record and `:prim_file` in favour of `File` and `File.Stat`

I'm not 100% sure about the last point (maybe I'm missing out on a reason to use `:prim_file` here), but it didn't look like features of `:prim_file` were being used that couldn't be replaced by `File` and `File.Stat`. Let me know if I can do anything else!