### PR TITLE
Add a small example to the `Plug.Builder` docs

### DIFF
--- a/lib/plug/builder.ex
+++ b/lib/plug/builder.ex
@@ -11,6 +11,11 @@ defmodule Plug.Builder do
         plug Plug.Logger
         plug :hello, upper: true
 
+        # A function from another module can be plugged too, provided it's
+        # imported into the current module first.
+        import AnotherModule, only: [interesting_plug: 2]
+        plug :interesting_plug
+
         def hello(conn, opts) do
           body = if opts[:upper], do: "WORLD", else: "world"
           send_resp(conn, 200, body)


### PR DESCRIPTION
I added a small example on how to plug a remote function in a `Plug.Builder` pipeline (by importing the function so that it's in the namespace).