### PR TITLE
Plug.Conn.update_resp_header/4

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -429,7 +429,7 @@ defmodule Plug.Conn do
   """
   @spec update_resp_header(t, binary, binary, (binary -> binary)) :: t
   def update_resp_header(%Conn{state: state} = conn, key, initial, fun) when
-      is_binary(key) and is_binary(initial) and is_function(fun) and state != :sent do
+      is_binary(key) and is_binary(initial) and is_function(fun, 1) and state != :sent do
     case get_resp_header(conn, key) do
       []          -> put_resp_header(conn, key, initial)
       [current|_] -> put_resp_header(conn, key, fun.(current))
@@ -437,7 +437,7 @@ defmodule Plug.Conn do
   end
 
   def update_resp_header(%Conn{}, key, initial, fun) when
-      is_binary(key) and is_binary(initial) and is_function(fun) do
+      is_binary(key) and is_binary(initial) and is_function(fun, 1) do
     raise AlreadySentError
   end
 

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -321,6 +321,29 @@ defmodule Plug.ConnTest do
     end
   end
 
+  test "update_resp_header/4" do
+    conn1 = conn(:head, "/foo") |> put_resp_header("x-foo", "bar")
+    conn2 = update_resp_header(conn1, "x-foo", "bong", &(&1 <> ", baz"))
+    assert get_resp_header(conn2, "x-foo") == ["bar, baz"]
+    assert length(conn1.resp_headers) == length(conn2.resp_headers)
+
+    conn1 = conn(:head, "/foo")
+    conn2 = update_resp_header(conn1, "x-foo", "bong", &(&1 <> ", baz"))
+    assert get_resp_header(conn2, "x-foo") == ["bong"]
+
+    conn1 = %{conn(:head, "/foo") | resp_headers:
+      [{"x-foo", "foo"}, {"x-foo", "bar"}]}
+    conn2 = update_resp_header(conn1, "x-foo", "in", &String.upcase/1)
+    assert get_resp_header(conn2, "x-foo") == ["FOO", "bar"]
+  end
+
+  test "update_resp_header/4 raises when the conn was already been sent" do
+    conn = conn(:head, "/foo") |> send_resp(200, "ok")
+    assert_raise Plug.Conn.AlreadySentError, fn ->
+      conn |> update_resp_header("x-foo", "init", &(&1))
+    end
+  end
+
   test "put_resp_content_type/3" do
     conn = conn(:head, "/foo")
 


### PR DESCRIPTION
I've found myself wanting a function that could update a possibly existing response header much like we're accustomed to with functions like `Dict.update/4` or `Ecto.Changeset.update_change/3`. The `Plug.Conn.update_resp_header/4` function behaves very similarly:

```elixir
update_resp_header(conn, "vary", "origin", &(&1 <> ", origin"))
```

This is a draft PR to get some feedback on the idea. A full and neat implementation would include also an `update_resp_header!/3` function.

**PS** don't pay too much attention on the implementation for now; I'm not sure how we should be supposed to update an header that appears multiple times in the `:resp_headers` field. The current implementation updates only the first occurrence, but they could all be updated or the `Keyword.update/4` approach could be adopted where the first occurrence is updated and all other occurrences are removed.

Looking forward to your feedback, thanks!