### PR TITLE
Fix documentation in Plug.Conn.async_assign/3 and Plug.Conn.await_assign/2

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -215,31 +215,30 @@ defmodule Plug.Conn do
   @doc """
   Starts a task to assign a value to a key in the connection.
 
+  `await_assign/2` can be used to wait for the async task to complete and
+  retrieve the resulting value.
+
   Behind the scenes, it uses `Task.async/1`.
 
   ## Examples
 
-    iex> conn.assigns[:hello]
-    nil
-
-    # fun is some function that returns :world
-    iex> conn = async_assign(conn, :hello, fn -> :world end)
-
-    # the following will block until conn.assigns[:hello] is available
-    iex> await_assign(conn, :hello)
-
-    # conn now has awaited value
-    iex> conn.assigns[:hello]
-    :world
+      iex> conn.assigns[:hello]
+      nil
+      iex> conn = async_assign(conn, :hello, fn -> :world end)
+      iex> conn.assigns[:hello]
+      %Task{...}
 
   """
-  @spec async_assign(t, atom, function) :: t
+  @spec async_assign(t, atom, (() -> term)) :: t
   def async_assign(%Conn{} = conn, key, fun) when is_atom(key) do
     assign(conn, key, Task.async(fun))
   end
 
   @doc """
-  Awaits the completion of an async assign, placing the result in the conn at key.
+  Awaits the completion of an async assign.
+
+  Returns a connection with the value resulting from the async assignment placed
+  under `key` in the `:assigns` field.
 
   Behind the scenes, it uses `Task.await/2`.
 
@@ -247,14 +246,8 @@ defmodule Plug.Conn do
 
       iex> conn.assigns[:hello]
       nil
-
-      # fun is some function that returns :world
       iex> conn = async_assign(conn, :hello, fn -> :world end)
-
-      # the following will block until conn.assigns[:hello] is available
-      iex> await_assign(conn, :hello)
-
-      # conn now has awaited value
+      iex> conn = await_assign(conn, :hello) # blocks until `conn.assings[:hello]` is available
       iex> conn.assigns[:hello]
       :world
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -230,7 +230,7 @@ defmodule Plug.Conn do
 
   """
   @spec async_assign(t, atom, (() -> term)) :: t
-  def async_assign(%Conn{} = conn, key, fun) when is_atom(key) do
+  def async_assign(%Conn{} = conn, key, fun) when is_atom(key) and is_function(fun, 0) do
     assign(conn, key, Task.async(fun))
   end
 


### PR DESCRIPTION
I also did something I'm not 100% sure of (that's why I stuffed it into an isolated commit, so I can nuke it :smiley:): added a check to the function head in `Plug.Conn.async_assign/3` that requires the `fun` argument to be a function with arity 0. I don't know it this can be useful, and if so, I don't know if it should be moved to `Task.async/1`. Let me know, so I can open a PR in Elixir if necessary :).