### PR TITLE
Add check for a conn state in `Conn.send_file/5` and remove it in `Conn.run_before_send/2`

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -740,11 +740,6 @@ defmodule Plug.Conn do
 
   ## Helpers
 
-  defp run_before_send(%Conn{state: state}, _new)
-       when not state in @unsent do
-    raise AlreadySentError
-  end
-
   defp run_before_send(%Conn{before_send: before_send} = conn, new) do
     conn = Enum.reduce before_send, %{conn | state: new}, &(&1.(&2))
     if conn.state != new do


### PR DESCRIPTION
`send_resp` and `send_chunked` are already have check for a conn state in them, thus `run_before_send` has a redundant check.