### PR TITLE
Parses body on delete

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -126,7 +126,7 @@ defmodule Plug.Parsers do
                     {:next, Conn.t}
 
   @behaviour Plug
-  @methods ~w(POST PUT PATCH)
+  @methods ~w(POST PUT PATCH DELETE)
 
   def init(opts) do
     parsers = Keyword.get(opts, :parsers) || raise_missing_parsers

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -19,10 +19,15 @@ defmodule Plug.ParsersTest do
     assert conn.params["foo"] == "bar"
   end
 
-  test "ignore bodies unless post/put/match" do
+  test "ignore bodies unless post/put/match/delete" do
     headers = [{"content-type", "application/x-www-form-urlencoded"}]
     conn = parse(conn(:get, "/?foo=bar", "foo=baz", headers: headers))
     assert conn.params["foo"] == "bar"
+
+    headers = [{"content-type", "application/x-www-form-urlencoded"}]
+    conn = parse(conn(:delete, "/?foo=bar", "bar=foo", headers: headers))
+    assert conn.params["foo"] == "bar"
+    assert conn.params["bar"] == "foo"
   end
 
   test "parses url encoded bodies" do


### PR DESCRIPTION
- Parses the body on a delete request
- RFC 7231 doesn't explicitly say a body is required but also doesn't explicitly say that a body isn't allowed
- Using this in a JSON API implementation (http://jsonapi.org/format/#crud-updating-to-many-relationships)

## RFC 7231
[RFC 7231 - Section 4.3.5](https://tools.ietf.org/html/rfc7231#section-4.3.5)
>A payload within a DELETE request message has no defined semantics; sending a payload body on a DELETE request might cause some existing implementations to reject the request.