### PR TITLE
Add Plug.Conn.clear_session/1

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -690,6 +690,17 @@ defmodule Plug.Conn do
   end
 
   @doc """
+  Clears the entire session.
+
+  This function removes every key from the session, effectively clearing the
+  session.
+  """
+  @spec clear_session(t) :: t
+  def clear_session(conn) do
+    put_session(conn, fn(_existing) -> Map.new end)
+  end
+
+  @doc """
   Configures the session.
 
   ## Options

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -692,8 +692,11 @@ defmodule Plug.Conn do
   @doc """
   Clears the entire session.
 
-  This function removes every key from the session, effectively clearing the
-  session.
+  This function removes every key from the session, clearing the session.
+
+  Note that, even if `clear_session/1` is used, the session is still sent to the
+  client. If the session should be effectively *dropped*, `configure_session/2`
+  should be used with the `:drop` option set to `true`.
   """
   @spec clear_session(t) :: t
   def clear_session(conn) do

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -607,6 +607,19 @@ defmodule Plug.ConnTest do
     assert get_session(conn, "baz") == nil
   end
 
+  test "clear_session/1" do
+    opts = Plug.Session.init(store: ProcessStore, key: "foobar")
+    conn = conn(:get, "/") |> Plug.Session.call(opts) |> fetch_session()
+
+    conn = conn
+            |> put_session("foo", "bar")
+            |> put_session("baz", "boom")
+            |> clear_session
+
+    assert get_session(conn, "foo") == nil
+    assert get_session(conn, "baz") == nil
+  end
+
   test "halt/1 updates halted to true" do
     conn = %Conn{}
     assert conn.halted == false


### PR DESCRIPTION
As suggested in #163, I added the `Plug.Conn.clear_session/1` function which removes all the stored keys from the session. Let me know if I got it right :), thanks!