### PR TITLE
Fixes and minor polishes to the `Plug.Session.Store` and `Plug.Session.ETS` docs

### DIFF
--- a/lib/plug/session/ets.ex
+++ b/lib/plug/session/ets.ex
@@ -2,25 +2,24 @@ defmodule Plug.Session.ETS do
   @moduledoc """
   Stores the session in an in-memory ETS table.
 
-  A created ETS table is required for this store to work.
-
-  This store does not create the ETS table, it is expected
-  that an existing named table is given as argument with
-  public properties.
+  This store does not create the ETS table; it expects that an existing named
+  table with public properties is passed as an argument.
 
   ## Options
 
-  * `:table` - ETS table name (required);
+  * `:table` - ETS table name (required)
+
+  For more information on ETS tables, visit the Erlang documentation at
+  http://www.erlang.org/doc/man/ets.html.
 
   ## Examples
 
-      # Create table during application start
+      # Create an ETS table when the application starts
       :ets.new(:session, [:named_table, :public, read_concurrency: true])
 
       # Use the session plug with the table name
       plug Plug.Session, store: :ets, key: "sid", table: :session
 
-  http://www.erlang.org/doc/man/ets.html
   """
 
   @behaviour Plug.Session.Store

--- a/lib/plug/session/store.ex
+++ b/lib/plug/session/store.ex
@@ -2,13 +2,14 @@ defmodule Plug.Session.Store do
   @moduledoc """
   Specification for session stores.
   """
+
   use Behaviour
 
   @type sid :: term | nil
   @type cookie :: binary
   @type session :: map
 
-  @moduledoc """
+  @doc """
   Initializes the store.
 
   The options returned from this function will be given
@@ -16,7 +17,7 @@ defmodule Plug.Session.Store do
   """
   defcallback init(Plug.opts) :: Plug.opts
 
-  @moduledoc """
+  @doc """
   Parses the given cookie.
 
   Returns a session id and the session contents. The session id is any
@@ -27,7 +28,7 @@ defmodule Plug.Session.Store do
   """
   defcallback get(Plug.Conn.t, cookie, Plug.opts) :: {sid, session}
 
-  @moduledoc """
+  @doc """
   Stores the session associated with given session id.
 
   If `nil` is given as id, a new session id should be
@@ -35,7 +36,7 @@ defmodule Plug.Session.Store do
   """
   defcallback put(Plug.Conn.t, sid, any, Plug.opts) :: cookie
 
-  @moduledoc """
+  @doc """
   Removes the session associated with given session id from the store.
   """
   defcallback delete(Plug.Conn.t, sid, Plug.opts) :: :ok


### PR DESCRIPTION
- Fixed a documentation bug (`@moduledoc`s instead of `@doc`s) in `Plug.Session.Store`
- Slightly rephrased a couple of sentences in the docs for `Plug.Session.ETS`