### PR TITLE
In upcoming Erlang/OTP 18, :erlang.now is deprecated.

### DIFF
--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -161,7 +161,8 @@ defmodule Plug.Upload do
   defp i(integer), do: Integer.to_string(integer)
 
   defp path(prefix, tmp) do
-    {_mega, sec, mili} = :os.timestamp
-    tmp <> "/" <> prefix <> "-" <> i(sec) <> "-" <> i(mili)
+    {_mega, sec, micro} = :os.timestamp
+    scheduler_id = :erlang.system_info(:scheduler_id)
+    tmp <> "/" <> prefix <> "-" <> i(sec) <> "-" <> i(micro) <> "-" <> i(scheduler_id)
   end
 end

--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -161,7 +161,7 @@ defmodule Plug.Upload do
   defp i(integer), do: Integer.to_string(integer)
 
   defp path(prefix, tmp) do
-    {_mega, sec, mili} = :erlang.now
+    {_mega, sec, mili} = :os.timestamp
     tmp <> "/" <> prefix <> "-" <> i(sec) <> "-" <> i(mili)
   end
 end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -237,7 +237,7 @@ defmodule Plug.ConnTest do
 
   test "send_file/5 limits on offset" do
     %File.Stat{type: :regular, size: size} = File.stat!(__ENV__.file)
-    :random.seed(:erlang.now)
+    :random.seed(:os.timestamp)
     offset = round(:random.uniform * size)
     conn = conn(:get, "/foo") |> send_file(206, __ENV__.file, offset)
     assert conn.status == 206
@@ -247,7 +247,7 @@ defmodule Plug.ConnTest do
 
   test "send_file/5 limits on offset and length" do
     %File.Stat{type: :regular, size: size} = File.stat!(__ENV__.file)
-    :random.seed(:erlang.now)
+    :random.seed(:os.timestamp)
     offset = round(:random.uniform * size)
     length = round((size - offset) * 0.25)
     conn = conn(:get, "/foo") |> send_file(206, __ENV__.file, offset, length)


### PR DESCRIPTION
Use :os.timestamp instead.

See also http://www.erlang.org/documentation/doc-7.0-rc1/erts-7.0/doc/html/time_correction.html#Dos_and_Donts