### PR TITLE
Documentation change for Plug.Conn

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -31,8 +31,11 @@ defmodule Plug.Conn do
 
   ## Fetchable fields
 
-  These fields contain request information that is not populated until they are fetched using using `fetch_params/2`.
-  If you access these fields before retrieving them with `fetch_params/2`, they will be returned as `Plug.Conn.Unfetched` structs.
+  The request information in these fields is not populated until it is fetched using
+  using the associated `fetch_` function. For example, the `params` field uses `fetch_params/2`.
+
+  If you access these fields before fetching them, they will be returned as 
+  `Plug.Conn.Unfetched` structs.
 
   * `cookies`- the request cookies with the response cookies
   * `params` - the request params

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -32,6 +32,7 @@ defmodule Plug.Conn do
   ## Fetchable fields
 
   The request information in these fields is not populated until it is fetched using
+  the associated `fetch_` function. For example, the `params` field uses `fetch_params/2`.
 
   If you access these fields before fetching them, they will be returned as 
   `Plug.Conn.Unfetched` structs.

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -32,7 +32,6 @@ defmodule Plug.Conn do
   ## Fetchable fields
 
   The request information in these fields is not populated until it is fetched using
-  using the associated `fetch_` function. For example, the `params` field uses `fetch_params/2`.
 
   If you access these fields before fetching them, they will be returned as 
   `Plug.Conn.Unfetched` structs.

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -12,7 +12,7 @@ defmodule Plug.Conn do
 
   ## Request fields
 
-  Those fields contain request information:
+  These fields contain request information:
 
   * `host` - the requested host as a binary, example: `"www.example.com"`
   * `method` - the request method as a binary, example: `"GET"`
@@ -31,8 +31,8 @@ defmodule Plug.Conn do
 
   ## Fetchable fields
 
-  Those fields contain request information and they need to be explicitly fetched.
-  Before fetching those fields return a `Plug.Conn.Unfetched` record.
+  These fields contain request information that is not populated until they are fetched using using `fetch_params/2`.
+  If you access these fields before retrieving them with `fetch_params/2`, they will be returned as `Plug.Conn.Unfetched` structs.
 
   * `cookies`- the request cookies with the response cookies
   * `params` - the request params
@@ -40,7 +40,7 @@ defmodule Plug.Conn do
 
   ## Response fields
 
-  Those fields contain response information:
+  These fields contain response information:
 
   * `resp_body` - the response body, by default is an empty string. It is set
     to nil after the response is set, except for test connections.
@@ -73,7 +73,7 @@ defmodule Plug.Conn do
 
   ## Private fields
 
-  Those fields are reserved for libraries/framework usage.
+  These fields are reserved for libraries/framework usage.
 
   * `adapter` - holds the adapter information in a tuple
   * `private` - shared library data as a dict


### PR DESCRIPTION
The puprose of this change is to clarify the documentation in the Plug.Conn class.  Apart from small, one-word changes, the primary change is to clarify the behavior of the 'fetchable fields' of a Connection.

Please carefully review the proposed changes to ensure that they match the behavior of the structure.