### PR TITLE
Log when a connection is halted by a plug

### DIFF
--- a/test/plug/builder_test.exs
+++ b/test/plug/builder_test.exs
@@ -44,7 +44,7 @@ defmodule Plug.BuilderTest do
   end
 
   defmodule Halter do
-    use Plug.Builder
+    use Plug.Builder, log_on_halt: :debug
 
     plug :step, :first
     plug :step, :second

--- a/test/plug/builder_test.exs
+++ b/test/plug/builder_test.exs
@@ -44,7 +44,7 @@ defmodule Plug.BuilderTest do
   end
 
   defmodule Halter do
-    use Plug.Builder, log_on_halt: :debug
+    use Plug.Builder
 
     plug :step, :first
     plug :step, :second
@@ -99,17 +99,13 @@ defmodule Plug.BuilderTest do
     assert conn.assigns[:entered_stack] == true
   end
 
-  test "halt/2 halts the plug stack and Logger.infos it" do
-    log = capture_log fn ->
-      conn = conn(:get, "/") |> Halter.call([])
-      assert conn.halted
-      assert conn.assigns[:first]
-      assert conn.assigns[:second]
-      assert conn.assigns[:authorize_reached]
-      refute conn.assigns[:end_of_chain_reached]
-    end
-
-    assert log =~ "plug pipeline halted in :authorize/2"
+  test "halt/2 halts the plug stack" do
+    conn = conn(:get, "/") |> Halter.call([])
+    assert conn.halted
+    assert conn.assigns[:first]
+    assert conn.assigns[:second]
+    assert conn.assigns[:authorize_reached]
+    refute conn.assigns[:end_of_chain_reached]
   end
 
   test "an exception is raised if a plug doesn't return a connection" do
@@ -141,12 +137,5 @@ defmodule Plug.BuilderTest do
         plug Bad
       end
     end
-  end
-
-  def capture_log(fun) do
-    ExUnit.CaptureIO.capture_io(:user, fn ->
-      fun.()
-      Logger.flush()
-    end) |> String.strip
   end
 end

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -2,10 +2,6 @@ defmodule Plug.StaticTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  setup do
-    Logger.disable(self)
-  end
-
   defmodule MyPlug do
     use Plug.Builder
 

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -2,6 +2,10 @@ defmodule Plug.StaticTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
+  setup do
+    Logger.disable(self)
+  end
+
   defmodule MyPlug do
     use Plug.Builder
 


### PR DESCRIPTION
This should implement #208.

For now, only the module/function plug is logged since I think logging the line where `halt/1` is called may be trickier (since halting happens in `Plug.Builder`, not in the call to `halt/1`).

I had to shush `Logger` inside the tests for `Plug.Static` in order to avoid having to capture the log everywhere in those tests.

Let me know if anything needs to be changed. Thanks!