### PR TITLE
Document the usage of the `:log_on_halt` option

### DIFF
--- a/lib/plug/builder.ex
+++ b/lib/plug/builder.ex
@@ -71,7 +71,6 @@ defmodule Plug.Builder do
         end
       end
 
-
   ## Halting a plug pipeline
 
   A plug pipeline can be halted with `Plug.Conn.halt/1`. The builder will
@@ -89,6 +88,20 @@ defmodule Plug.Builder do
           halt(conn)
         end
       end
+
+  You can log when a connection is halted through the `:log_on_halt` option; see
+  the "Options" section for more information.
+
+  ## Options
+
+  Here is a list of options supported by `Plug.Builder`:
+
+    * `:log_on_halt` - specifies whether to log when a connection is halted
+      through `Plug.Conn.halt/1`. The value of this option must be an atom
+      representing the log level with which this information should be logged;
+      the supported log levels are the ones used by Elixir's `Logger`, i.e.,
+      `:debug`, `:info`, `:warn`, and `:error`. This option defaults to `nil`,
+      meaning *no logging* happens when a connection is halted.
 
   """
 

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -142,15 +142,24 @@ defmodule Plug.Router do
   After a match is found, the block given as `do/end` is stored
   as a function in the connection. This function is then retrieved
   and invoked in the `dispatch` plug.
+
+  ## Options
+
+  For now, `Plug.Router` only support one option that is actually a
+  `Plug.Builder` option: `:log_on_halt`. See the documentation for
+  `Plug.Builder` to learn more.
+
   """
 
   @doc false
-  defmacro __using__(_) do
+  defmacro __using__(opts) do
     quote location: :keep do
       import Plug.Router
       @before_compile Plug.Router
 
-      use Plug.Builder
+      builder_opts = Keyword.take(unquote(opts), [:log_on_halt])
+
+      use Plug.Builder, builder_opts
 
       defp match(conn, _opts) do
         Plug.Conn.put_private(conn,


### PR DESCRIPTION
Forgot to add docs to #221. I added them both in `Plug.Builder` and in `Plug.Router`, which just forwards the `:log_on_halt` option to `Plug.Builder`.