### PR TITLE
Test for no boundary on multipart requests

### DIFF
--- a/lib/plug/parsers/multipart.ex
+++ b/lib/plug/parsers/multipart.ex
@@ -8,7 +8,11 @@ defmodule Plug.Parsers.MULTIPART do
   def parse(conn, "multipart", subtype, _headers, opts) when subtype in ["form-data", "mixed"] do
     {adapter, state} = conn.adapter
 
-    case adapter.parse_req_multipart(state, opts, &handle_headers/1) do
+    try do
+      adapter.parse_req_multipart(state, opts, &handle_headers/1)
+    rescue
+      e -> raise Plug.Parsers.ParseError, exception: e
+    else
       {:ok, params, state} ->
         {:ok, params, %{conn | adapter: {adapter, state}}}
       {:more, _params, state} ->

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -248,7 +248,7 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
     assert body =~ "invalid UTF-8 on multipart body, got byte 139"
   end
 
-  test "validates boundary on multipart requests" do
+  test "returns parse error when body is badly formatted in multipart requests" do
     multipart = """
     ------w58EW1cEpjzydSCq\r
     Content-Disposition: form-data; name=\"name\"\r
@@ -260,7 +260,8 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
        {"Content-Length", byte_size(multipart)}]
 
     assert {500, _, body} = request :post, "/multipart", headers, multipart
-    assert body =~ "malformed request, got"
+    assert body =~ "malformed request, got MatchError with message " <>
+      "no match of right hand side value: false"
   end
 
   def https(conn) do

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -248,6 +248,21 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
     assert body =~ "invalid UTF-8 on multipart body, got byte 139"
   end
 
+  test "validates boundary on multipart requests" do
+    multipart = """
+    ------w58EW1cEpjzydSCq\r
+    Content-Disposition: form-data; name=\"name\"\r
+    ------w58EW1cEpjzydSCq\r
+    """
+
+    headers =
+      [{"Content-Type", "multipart/form-data"},
+       {"Content-Length", byte_size(multipart)}]
+
+    assert {500, _, body} = request :post, "/multipart", headers, multipart
+    assert body =~ "malformed request, got"
+  end
+
   def https(conn) do
     assert conn.scheme == :https
     send_resp(conn, 200, "OK")


### PR DESCRIPTION
refs: https://github.com/elixir-lang/plug/issues/236

I created a test that reproduces the error at https://github.com/phoenixframework/phoenix/issues/859. I noticed that there are a bunch of badly formatted multipart requests that can break the `:cowboy_req.part/2` call. Is it safe to assume that all `:badarg` errors raised by `:cowboy_req` are due to badly formatted requests from the client? If so, should we do a try block that catches `:badarg` errors and reraise a `Plug.Parsers.ParseError`?

Another option I was thinking was to validate multipart request body in `Plug.Parsers.MULTIPART.parse/5` before calling `adapter.parse_req_multipart/3`. 

Do you have some other approach in mind @josevalim or are any of the above approaches viable?
