### PR TITLE
Split logger/request_id plugs

### DIFF
--- a/lib/plug/request_id.ex
+++ b/lib/plug/request_id.ex
@@ -1,0 +1,63 @@
+defmodule Plug.RequestId do
+  @moduledoc """
+  A plug for generating a unique request id for each request. A generated
+  request id will in the format "uq8hs30oafhj5vve8ji5pmp7mtopc08f".
+
+  If a request id already exists as the "x-request-id" HTTP request header,
+  then that value will be used assuming it is between 20 and 200 characters.
+  If it is not, a new request id will be generated.
+
+  The request id is added to the Logger metadata as `:request_id` and the response as
+  the "x-request-id" HTTP header. To see the request id in your log output,
+  configure your logger backends to include the `:request_id` metadata in:
+
+      config :logger, :console, metadata: [:request_id]
+
+  It is recommended to include this metadata configuration in your production
+  configuration file.
+
+  To use it, just plug it into the desired module:
+
+      plug Plug.RequestId
+
+  ## Options
+
+    * `:http_header` - The name of the HTTP *request* header to check for
+    existing request ids. This is also the HTTP *response* header that will be
+    set with the request id. Default value is "x-request-id"
+
+        plug Plug.RequestId, http_header: "custom-request-id"
+  """
+
+  require Logger
+  alias Plug.Conn
+  @behaviour Plug
+
+  def init(opts) do
+    Keyword.get(opts, :http_header, "x-request-id")
+  end
+
+  def call(conn, req_id_header) do
+    conn
+    |> get_request_id(req_id_header)
+    |> set_request_id(req_id_header)
+  end
+
+  defp get_request_id(conn, header) do
+    case Conn.get_req_header(conn, header) do
+      []      -> {conn, generate_request_id}
+      [val|_] -> if valid_request_id?(val), do: {conn, val}, else: {conn, generate_request_id}
+    end
+  end
+
+  defp set_request_id({conn, request_id}, header) do
+    Logger.metadata(request_id: request_id)
+    conn |> Conn.put_resp_header(header, request_id)
+  end
+
+  defp generate_request_id do
+    :crypto.rand_bytes(20) |> Base.hex_encode32(case: :lower)
+  end
+
+  defp valid_request_id?(s), do: byte_size(s) in 20..200
+end

--- a/test/plug/logger_test.exs
+++ b/test/plug/logger_test.exs
@@ -48,35 +48,12 @@ defmodule Plug.LoggerTest do
 
   test "logs proper message to console" do
     {_conn, [first_message, second_message]} = conn(:get, "/") |> call
-    assert Regex.match?(~r/request_id=[^-A-Za-z0-9+\/=]|=[^=]|={3,} [info]  GET \//u, first_message)
+    assert Regex.match?(~r/\[info\]  GET \//u, first_message)
     assert Regex.match?(~r/Sent 200 in [0-9]+[µm]s/u, second_message)
 
     {_conn, [first_message, second_message]} = conn(:get, "/hello/world") |> call
-    assert Regex.match?(~r/request_id=[^-A-Za-z0-9+\/=]|=[^=]|={3,} [info]  GET hello\/world/u, first_message)
+    assert Regex.match?(~r/\[info\]  GET \/hello\/world/u, first_message)
     assert Regex.match?(~r/Sent 200 in [0-9]+[µm]s/u, second_message)
-  end
-
-  test "adds request id to headers" do
-    {conn, _} = conn(:get, "/hello/work") |> call
-    refute Plug.Conn.get_resp_header(conn, "x-request-id") == nil
-  end
-
-  test "returns request id from request headers" do
-    request_id = "01234567890123456789"
-    {conn, _}  = conn(:get, "/hello/work")
-                 |> put_req_header("x-request-id", request_id)
-                 |> call
-
-    assert Plug.Conn.get_resp_header(conn, "x-request-id") == [request_id]
-  end
-
-  test "generates new request id for invalid request_id" do
-    request_id = "01234567890"
-    {conn, _}  = conn(:get, "/hello/work")
-                 |> put_req_header("x-request-id", request_id)
-                 |> call
-
-    refute Plug.Conn.get_resp_header(conn, "x-request-id") == [request_id]
   end
 
   test "logs chunked if chunked reply" do

--- a/test/plug/request_id_test.exs
+++ b/test/plug/request_id_test.exs
@@ -1,0 +1,85 @@
+defmodule Plug.RequestIdTest do
+
+  use ExUnit.Case
+  use Plug.Test
+  alias Plug.Conn
+
+  defmodule MyPlug do
+    use Plug.Builder
+
+    plug Plug.RequestId
+    plug :passthrough
+
+    defp passthrough(conn, _) do
+      Plug.Conn.send_resp(conn, 200, "Passthrough")
+    end
+  end
+
+  defmodule CustomHeaderPlug do
+    use Plug.Builder
+
+    plug Plug.RequestId, http_header: "custom-request-id"
+    plug :passthrough
+
+    defp passthrough(conn, _) do
+      Plug.Conn.send_resp(conn, 200, "Passthrough")
+    end
+  end
+
+  test "generates new request id if none exists" do
+    conn = conn(:get, "/") |> MyPlug.call([])
+    [res_request_id] = conn |> Conn.get_resp_header("x-request-id")
+    meta_request_id = Dict.fetch!(Logger.metadata, :request_id)
+    assert generated_request_id?(res_request_id)
+    assert res_request_id == meta_request_id
+  end
+
+  test "generates new request id if existing one is invalid" do
+    request_id = "tooshort"
+    conn =
+      conn(:get, "/")
+      |> put_req_header("x-request-id", request_id)
+      |> MyPlug.call([])
+    [res_request_id] = conn |> Conn.get_resp_header("x-request-id")
+    meta_request_id = Dict.fetch!(Logger.metadata, :request_id)
+    assert res_request_id != request_id
+    assert generated_request_id?(res_request_id)
+    assert res_request_id == meta_request_id
+  end
+
+  test "uses existing request id" do
+    request_id = "existingidthatislongenough"
+    conn =
+      conn(:get, "/")
+      |> put_req_header("x-request-id", request_id)
+      |> MyPlug.call([])
+    [res_request_id] = conn |> Conn.get_resp_header("x-request-id")
+    meta_request_id = Dict.fetch!(Logger.metadata, :request_id)
+    assert res_request_id == request_id
+    assert res_request_id == meta_request_id
+  end
+
+  test "generates new request id in custom header" do
+    conn = conn(:get, "/") |> CustomHeaderPlug.call([])
+    [res_request_id] = conn |> Conn.get_resp_header("custom-request-id")
+    meta_request_id = Dict.fetch!(Logger.metadata, :request_id)
+    assert Regex.match?(~r/^[a-z0-9=]+$/u, res_request_id)
+    assert res_request_id == meta_request_id
+  end
+
+  test "uses existing request id in custom header" do
+    request_id = "existingidthatislongenough"
+    conn =
+      conn(:get, "/")
+      |> put_req_header("custom-request-id", request_id)
+      |> CustomHeaderPlug.call([])
+    [res_request_id] = conn |> Conn.get_resp_header("custom-request-id")
+    meta_request_id = Dict.fetch!(Logger.metadata, :request_id)
+    assert res_request_id == request_id
+    assert res_request_id == meta_request_id
+  end
+
+  defp generated_request_id?(request_id) do
+    Regex.match?(~r/^[a-z0-9=]+$/u, request_id)
+  end
+end


### PR DESCRIPTION
Break up the current Logger plug into two separate plugs each individually
responsible for:

* The generation of a request id that is added as an HTTP request and response
  header
* The logging of the request along with any associated (HTTP header based)
  request id

@josevalim, quick question before I finalize the PR: I wasn't sure why there was so much [verification of the request id format](https://github.com/elixir-lang/plug/blob/055e21724cde595a8c4b8434be1120d94efc0dc3/lib/plug/logger.ex#L73-L95) in the original plug. Should that logic be retained?

Closes #246