### PR TITLE
Fix typo with session cookie docs

### DIFF
--- a/lib/plug/session/cookie.ex
+++ b/lib/plug/session/cookie.ex
@@ -54,7 +54,7 @@ defmodule Plug.Session.COOKIE do
   alias Plug.Crypto.MessageEncryptor
 
   def init(opts) do
-    encryption_salt = opts[:encrypted_salt]
+    encryption_salt = opts[:encryption_salt]
     signing_salt = check_signing_salt(opts)
 
     iterations = Keyword.get(opts, :key_iterations, 1000)


### PR DESCRIPTION
RFC @josevalim — Update the session cookie code to use the opt key outlined in the documentation.

Closes #253.