### PR TITLE
Request header helper functions. Closes #250

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -460,6 +460,60 @@ defmodule Plug.Conn do
   end
 
   @doc """
+  Adds a new request header (`key`) if not present, otherwise replaces the
+  previous value of that header with `value`.
+
+  Raises a `Plug.Conn.AlreadySentError` if the connection has already been
+  `:sent`.
+  """
+  @spec put_req_header(t, binary, binary) :: t
+  def put_req_header(%Conn{state: :sent}, _key, _value) do
+    raise AlreadySentError
+  end
+
+  def put_req_header(%Conn{req_headers: headers} = conn, key, value) when
+      is_binary(key) and is_binary(value) do
+    unless valid_header_key?(key), do: raise(InvalidHeaderKeyFormatError, message: "header key is not lowercase: "<>key)
+    %{conn | req_headers: List.keystore(headers, key, 0, {key, value})}
+  end
+
+  @doc """
+  Deletes a request header if present.
+
+  Raises a `Plug.Conn.AlreadySentError` if the connection has already been
+  `:sent`.
+  """
+  @spec delete_req_header(t, binary) :: t
+  def delete_req_header(%Conn{state: :sent}, _key) do
+    raise AlreadySentError
+  end
+
+  def delete_req_header(%Conn{req_headers: headers} = conn, key) when
+      is_binary(key) do
+    %{conn | req_headers: List.keydelete(headers, key, 0)}
+  end
+
+  @doc """
+  Updates a request header if present, otherwise it sets it to an initial
+  value.
+
+  Raises a `Plug.Conn.AlreadySentError` if the connection has already been
+  `:sent`.
+  """
+  @spec update_req_header(t, binary, binary, (binary -> binary)) :: t
+  def update_req_header(%Conn{state: :sent}, _key, _initial, _fun) do
+    raise AlreadySentError
+  end
+
+  def update_req_header(%Conn{} = conn, key, initial, fun) when
+      is_binary(key) and is_binary(initial) and is_function(fun, 1) do
+    case get_req_header(conn, key) do
+      []          -> put_req_header(conn, key, initial)
+      [current|_] -> put_req_header(conn, key, fun.(current))
+    end
+  end
+
+  @doc """
   Returns the values of the response header specified by `key`.
 
   ## Examples

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -86,24 +86,6 @@ defmodule Plug.Test do
   end
 
   @doc """
-  Puts a new request header.
-
-  Previous entries of the same header are overridden.
-  """
-  @spec put_req_header(Conn.t, binary, binary) :: Conn.t
-  def put_req_header(%Conn{req_headers: headers} = conn, key, value) when is_binary(key) and is_binary(value) do
-    %{conn | req_headers: :lists.keystore(key, 1, headers, {key, value})}
-  end
-
-  @doc """
-  Deletes a request header.
-  """
-  @spec delete_req_header(Conn.t, binary) :: Conn.t
-  def delete_req_header(%Conn{req_headers: headers} = conn, key) when is_binary(key) do
-    %{conn | req_headers: :lists.keydelete(key, 1, headers)}
-  end
-
-  @doc """
   Puts a request cookie.
   """
   @spec put_req_cookie(Conn.t, binary, binary) :: Conn.t

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -424,6 +424,66 @@ defmodule Plug.ConnTest do
     assert get_req_header(conn, "foo") == []
   end
 
+  test "put_req_header/3" do
+    conn1 = conn(:head, "/foo") |> put_req_header("x-foo", "bar")
+    assert get_req_header(conn1, "x-foo") == ["bar"]
+    conn2 = conn1 |> put_req_header("x-foo", "baz")
+    assert get_req_header(conn2, "x-foo") == ["baz"]
+    assert length(conn1.req_headers) ==
+           length(conn2.req_headers)
+  end
+
+  test "put_req_header/3 raises when the conn was already been sent" do
+    conn = conn(:get, "/foo") |> send_resp(200, "ok")
+    assert_raise Plug.Conn.AlreadySentError, fn ->
+      conn |> put_req_header("x-foo", "bar")
+    end
+  end
+
+  test "put_req_header/3 raises when invalid header key given" do
+    conn = conn(:get, "/foo")
+    assert_raise Plug.Conn.InvalidHeaderKeyFormatError, "header key is not lowercase: X-Foo", fn ->
+      conn |> put_req_header("X-Foo", "bar")
+    end
+  end
+
+  test "delete_req_header/2" do
+    conn = conn(:head, "/foo") |> put_req_header("x-foo", "bar")
+    assert get_req_header(conn, "x-foo") == ["bar"]
+    conn = conn |> delete_req_header("x-foo")
+    assert get_req_header(conn, "x-foo") == []
+  end
+
+  test "delete_req_header/2 raises when the conn was already been sent" do
+    conn = conn(:head, "/foo") |> send_resp(200, "ok")
+    assert_raise Plug.Conn.AlreadySentError, fn ->
+      conn |> delete_req_header("x-foo")
+    end
+  end
+
+  test "update_req_header/4" do
+    conn1 = conn(:head, "/foo") |> put_req_header("x-foo", "bar")
+    conn2 = update_req_header(conn1, "x-foo", "bong", &(&1 <> ", baz"))
+    assert get_req_header(conn2, "x-foo") == ["bar, baz"]
+    assert length(conn1.req_headers) == length(conn2.req_headers)
+
+    conn1 = conn(:head, "/foo")
+    conn2 = update_req_header(conn1, "x-foo", "bong", &(&1 <> ", baz"))
+    assert get_req_header(conn2, "x-foo") == ["bong"]
+
+    conn1 = %{conn(:head, "/foo") | req_headers:
+      [{"x-foo", "foo"}, {"x-foo", "bar"}]}
+    conn2 = update_req_header(conn1, "x-foo", "in", &String.upcase/1)
+    assert get_req_header(conn2, "x-foo") == ["FOO", "bar"]
+  end
+
+  test "update_req_header/4 raises when the conn was already been sent" do
+    conn = conn(:head, "/foo") |> send_resp(200, "ok")
+    assert_raise Plug.Conn.AlreadySentError, fn ->
+      conn |> update_req_header("x-foo", "init", &(&1))
+    end
+  end
+
   test "read_body/1" do
     body = :binary.copy("abcdefghij", 1000)
     conn = conn(:post, "/foo", body) |> put_req_header("content-type", "text/plain")

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -2,6 +2,7 @@ defmodule Plug.ParsersTest do
   use ExUnit.Case, async: true
 
   import Plug.Test
+  import Plug.Conn
 
   def parse(conn, opts \\ []) do
     opts = Keyword.put_new(opts, :parsers, [Plug.Parsers.URLENCODED, Plug.Parsers.MULTIPART])
@@ -54,7 +55,7 @@ defmodule Plug.ParsersTest do
   end
 
   test "raises on invalid url encoded" do
-    assert_raise Plug.Parsers.BadEncodingError, 
+    assert_raise Plug.Parsers.BadEncodingError,
                  "invalid UTF-8 on urlencoded body, got byte 139", fn ->
       conn(:post, "/foo", "a=" <> <<139>>)
       |> put_req_header("content-type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
Not sure if we want to throw `AlreadySentError`s when setting request headers on already sent connections? This certainly makes sense when setting response headers, not sure it does with request headers.