### PR TITLE
Add arguments to frame when available

### DIFF
--- a/lib/plug/templates/debugger.eex
+++ b/lib/plug/templates/debugger.eex
@@ -653,7 +653,26 @@
                           <% end %>
                         </div>
                     </header>
+
+                    <div class="sub">
+                        <h3>Frame</h3>
+                        <div class="inset variables">
+                            <table class="var_table">
+                                <tr>
+                                    <td class="name">Function</td>
+                                    <td><%= h(frame.info) %> (<%= h(frame.app) %>)</td>
+                                </tr>
+                                <%= if frame.args != [] do %>
+                                    <tr>
+                                        <td class="name">Args</td>
+                                        <td><%= h(inspect frame.args) %></td>
+                                    </tr>
+                                <% end %>
+                            </table>
+                        </div>
+                    </div>
                 </div>
+
             <% end %>
 
             <div class="sub">


### PR DESCRIPTION
Clicking on each frame toggles the 'Frame' section.
When no args are available, only shows function/arity.

Example:

![](https://www.evernote.com/shard/s307/sh/2c2ea8a6-e433-4a7f-b744-6428c8ac9817/57eb4b69ef55ee02/res/31978435-2dbc-4410-b709-6fd403c1079b/screenshot.png?resizeSmall&width=832)