### PR TITLE
Added get_private/2 and delete_private/2

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -312,6 +312,26 @@ defmodule Plug.Conn do
   end
 
   @doc """
+  Returns private value for the given `key`.
+
+  The key must be an atom.
+  """
+  @spec get_private(t, atom) :: any
+  def get_private(%Conn{private: private}, key) when is_atom(key) do
+    Map.get(private, key)
+  end
+
+  @doc """
+  Deletes the given `key` and its value from private.
+
+  The key must be an atom.
+  """
+  @spec delete_private(t, atom) :: t
+  def delete_private(%Conn{private: private} = conn, key) when is_atom(key) do
+    %{conn | private: Map.delete(private, key)}
+  end
+
+  @doc """
   Stores the given status code in the connection.
 
   The status code can be `nil`, an integer or an atom. The list of allowed

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -73,6 +73,20 @@ defmodule Plug.ConnTest do
     assert conn.private[:hello] == :world
   end
 
+  test "get_private/2" do
+    conn = conn(:get, "/")
+    refute get_private(conn, :hello)
+    conn = put_private(conn, :hello, :world)
+    assert get_private(conn, :hello) == :world
+  end
+
+  test "delete_private/2" do
+    conn = conn(:get, "/")
+    |> put_private(:hello, :world)
+    |> delete_private(:hello)
+    refute get_private(conn, :hello)
+  end
+
   test "scheme, host and port fields" do
     conn = conn(:get, "/")
     assert conn.scheme == :http


### PR DESCRIPTION
Added `get_private/2` and `delete_private/2` to make working with `conn.private` a bit easier.