### PR TITLE
Upgrade hackney to allow development on OTP 18

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Plug.Mixfile do
      {:earmark, "~> 0.1", only: :docs},
      {:ex_doc, "~> 0.7", only: :docs},
      {:inch_ex, only: :docs},
-     {:hackney, "~> 0.13", only: :test}]
+     {:hackney, "~> 1.2.0", only: :test}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -2,8 +2,9 @@
   "cowlib": {:hex, :cowlib, "1.0.0"},
   "earmark": {:hex, :earmark, "0.1.13"},
   "ex_doc": {:hex, :ex_doc, "0.7.2"},
-  "hackney": {:hex, :hackney, "0.13.1"},
-  "idna": {:hex, :idna, "1.0.1"},
+  "hackney": {:hex, :hackney, "1.2.0"},
+  "idna": {:hex, :idna, "1.0.2"},
   "inch_ex": {:hex, :inch_ex, "0.2.1"},
   "json": {:hex, :json, "0.3.2"},
-  "ranch": {:hex, :ranch, "1.0.0"}}
+  "ranch": {:hex, :ranch, "1.0.0"},
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}


### PR DESCRIPTION
Plug uses hackney as http client for the tests. Hackney 0.13 (that's specified in mix.exs) does not support OTP 18.

- Update tests for `Plug.Adapters.Cowboy.Conn` to allow for hackney's updated
  success signature for `HEAD` requests (hackney >= 0.14.0)

- Send self-signed certificate as `cacertfile` in `ssl_options` to hackney https
  request. Otherwise it will respond with `{:tls_alert, 'bad certificate'}`.