### PR TITLE
Log conn.request_path instead of Conn.full_path, remove Conn.full_path

### DIFF
--- a/lib/plug/adapters/translator.ex
+++ b/lib/plug/adapters/translator.ex
@@ -46,9 +46,6 @@ defmodule Plug.Adapters.Translator do
   end
 
   defp request_info(%Plug.Conn{method: method, query_string: query_string} = conn) do
-    ["Request: ", method, ?\s, path_to_iodata(conn, query_string), ?\n]
+    ["Request: ", method, ?\s, conn.request_path, ?\n]
   end
-
-  defp path_to_iodata(path, ""), do: Plug.Conn.full_path(path)
-  defp path_to_iodata(path, qs), do: [Plug.Conn.full_path(path), ??, qs]
 end

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -18,7 +18,7 @@ defmodule Plug.Conn do
   * `method` - the request method as a binary, example: `"GET"`
   * `path_info` - the path split into segments, example: `["hello", "world"]`
   * `script_name` - the initial portion of the URL's path that corresponds to the application
-    routing, as segments, example: ["sub","app"]. It can be used to recover the `full_path/1`
+    routing, as segments, example: ["sub","app"].
   * `request_path` - the requested path, example: `/trailing/and//double//slashes/`
   * `port` - the requested port as an integer, example: `80`
   * `peer` - the actual TCP peer that connected, example: `{{127, 0, 0, 1}, 12345}`. Often this
@@ -207,27 +207,6 @@ defmodule Plug.Conn do
   alias Plug.Conn
   @already_sent {:plug_conn, :sent}
   @unsent [:unset, :set]
-
-  @doc """
-  Receives the connection and returns the full requested path as a string.
-
-  The full path of a request is made by joining its `script_name`
-  with its `path_info`.
-
-  ## Examples
-
-      iex> conn = %{conn | script_name: ["foo"], path_info: ["bar", "baz"]}
-      iex> full_path(conn)
-      "/foo/bar/baz"
-
-  """
-  @spec full_path(t) :: String.t
-  def full_path(conn)
-
-  def full_path(%Conn{script_name: [], path_info: []}), do:
-    "/"
-  def full_path(%Conn{script_name: script, path_info: path}), do:
-    "/" <> Enum.join(script ++ path, "/")
 
   @doc """
   Assigns a value to a key in the connection

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -275,8 +275,11 @@ defmodule Plug.Debugger do
   defp method(%Plug.Conn{method: method}), do:
     method
 
+  defp request_path(%Plug.Conn{request_path: request_path}), do:
+    request_path
+
   defp url(%Plug.Conn{scheme: scheme, host: host, port: port} = conn), do:
-    "#{scheme}://#{host}:#{port}#{full_path(conn)}"
+    "#{scheme}://#{host}:#{port}#{conn.request_path}"
 
   defp peer(%Plug.Conn{peer: {host, port}}), do:
     "#{:inet_parse.ntoa host}:#{port}"

--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -26,7 +26,7 @@ defmodule Plug.Logger do
   def call(conn, level) do
 
     Logger.log level, fn ->
-      [conn.method, ?\s, Conn.full_path(conn)]
+      [conn.method, ?\s, conn.request_path]
     end
 
     before_time = :os.timestamp()

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -55,7 +55,7 @@ defmodule Plug.SSL do
     status = if conn.method in ~w(HEAD GET), do: 301, else: 307
 
     uri = %URI{scheme: "https", host: custom_host || host,
-               path: full_path(conn), query: conn.query_string}
+               path: conn.request_path, query: conn.query_string}
 
     conn
     |> put_resp_header("location", to_string(uri))

--- a/lib/plug/templates/debugger.eex
+++ b/lib/plug/templates/debugger.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title><%= @title %> at <%= method(@conn) %> <%= full_path(@conn) %></title>
+    <title><%= @title %> at <%= method(@conn) %> <%= request_path(@conn) %></title>
     <style>
     /* Basic reset */
     * {
@@ -592,7 +592,7 @@
 <body>
     <div class="top">
         <header class="exception">
-            <h2><strong><%= @title %></strong> <span>at <%= method(@conn) %> <%= full_path(@conn) %></span></h2>
+            <h2><strong><%= @title %></strong> <span>at <%= method(@conn) %> <%= request_path(@conn) %></span></h2>
             <p><%= @message %></p>
         </header>
     </div>

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -124,17 +124,6 @@ defmodule Plug.ConnTest do
     assert conn.resp_body == nil
   end
 
-  test "full_path/1" do
-    conn = conn(:get, "/")
-    assert full_path(conn) == "/"
-
-    conn = %{conn | path_info: ["bar", "baz"]}
-    assert full_path(conn) == "/bar/baz"
-
-    conn = %{conn | script_name: ["foo"]}
-    assert full_path(conn) == "/foo/bar/baz"
-  end
-
   test "resp/3" do
     conn = conn(:get, "/foo")
     assert conn.state == :unset

--- a/test/plug/logger_test.exs
+++ b/test/plug/logger_test.exs
@@ -56,6 +56,11 @@ defmodule Plug.LoggerTest do
     assert Regex.match?(~r/Sent 200 in [0-9]+[µm]s/u, second_message)
   end
 
+  test "logs paths with double slashes and trailing slash" do
+    {_conn, [first_message, _]} = conn(:get, "/hello//world/") |> call
+    assert Regex.match?(~r/\/hello\/\/world\//u, first_message)
+  end
+
   test "logs chunked if chunked reply" do
     {_, [_, second_message]} = capture_log(fn ->
        conn(:get, "/hello/world") |> MyChunkedPlug.call([])


### PR DESCRIPTION
I noticed when looking at the logs for my app that paths with double slashes or trailing slashes were not being logged correctly.  

The reason is that the `Conn.full_path` method was being called instead of using the new `conn.request_path` (added recently).  `Conn.full_path` reconstructs the path based on `conn.path` and `conn.script_name`, which are both lists, joined together on '/'.  That's why they lose information.

After updating the logging method to use `conn.request_path` (first commit) I decided that `Conn.full_path` is pretty much useless since it's a worse version of `conn.request_path`, so my second commit completely removes `Conn.full_path`.

I left `Conn.script_name` since it might be useful for something other than generating `Conn.full_path` but I'm happy to remove it as well if you think it's not useful anymore.

This pull request has 2 commits - the first one is backwards-compatible, and the second would be a breaking API change.  This is my first pull request so I'm not sure what the policy is on this.