### PR TITLE
Raise when body is nil on resp/3

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -428,6 +428,10 @@ defmodule Plug.Conn do
     raise AlreadySentError
   end
 
+  def resp(%Conn{}, _status, nil) do
+    raise ArgumentError, "response body cannot be set to nil"
+  end
+
   def resp(%Conn{} = conn, status, body)
       when is_binary(body) or is_list(body) do
     %{conn | status: Plug.Conn.Status.code(status), resp_body: body, state: :set}

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -145,6 +145,13 @@ defmodule Plug.ConnTest do
     end
   end
 
+  test "resp/3 raises when body is nil" do
+    conn = conn(:head, "/foo")
+    assert_raise ArgumentError, fn ->
+      resp(conn, 200, nil)
+    end
+  end
+
   test "send_resp/3" do
     conn = conn(:get, "/foo")
     assert conn.state == :unset


### PR DESCRIPTION
In the typespecs for Plug.Conn, body can either be `iodata` or `nil`. `send_resp/3` uses those type specs which allows `nil` as argument for `body`. However, `resp/3` which is invoked by `send_resp/3`, does not allow `nil`.

Users that pass `nil` to `send_resp/3` get a confusing `no function clause matching error` because of this. And the typespecs in the docs that `body` can accept `iodata | nil`. Added another clause for `resp/3` here so we raise a clearer error message.