### PR TITLE
Expose cowboy's :timeout protocol configuration option

### DIFF
--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -145,7 +145,7 @@ defmodule Plug.Adapters.Cowboy do
     acceptors = cowboy_options[:acceptors] || 100
     dispatch  = :cowboy_router.compile(cowboy_options[:dispatch])
     compress  = cowboy_options[:compress] || false
-    timeout_option    = if cowboy_options[:timeout] do [timeout: cowboy_options[:timeout]] else [] end
+    timeout_option    = if timeout = cowboy_options[:timeout], do: [timeout: timeout], else: []
     transport_options = [env: [dispatch: dispatch], compress: compress] ++ timeout_option
     cowboy_options    = Keyword.drop(cowboy_options, @not_cowboy_options)
 

--- a/test/plug/adapters/cowboy_test.exs
+++ b/test/plug/adapters/cowboy_test.exs
@@ -27,6 +27,14 @@ defmodule Plug.Adapters.CowboyTest do
             [env: [dispatch: @dispatch], compress: false]]
   end
 
+  test "builds args with timeout option" do
+    assert args(:http, __MODULE__, [], [port: 3000, acceptors: 25, timeout: 30000]) ==
+           [Plug.Adapters.CowboyTest.HTTP,
+            25,
+            [port: 3000],
+            [env: [dispatch: @dispatch], compress: false, timeout: 30000]]
+  end
+
   test "builds child specs" do
     args = [Plug.Adapters.CowboyTest.HTTP,
             100,


### PR DESCRIPTION
Plug currently only allows configuring the :compress option. This change also allows :timeout option to be configured. Cowboys current default is only 5 seconds which may limit connection reuse.

:timeout` - Time in ms with no requests before Cowboy closes the connection.