### PR TITLE
Lets use new syntax '@callback' instead of 'use Behaviour', fix typo in documentation for ssl.ex

### DIFF
--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -54,11 +54,10 @@ defmodule Plug do
 
   @type opts :: tuple | atom | integer | float | [opts]
 
-  use Behaviour
   use Application
 
-  defcallback init(opts) :: opts
-  defcallback call(Plug.Conn.t, opts) :: Plug.Conn.t
+  @callback init(opts) :: opts
+  @callback call(Plug.Conn.t, opts) :: Plug.Conn.t
 
   @doc false
   def start(_type, _args) do

--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -2,7 +2,6 @@ defmodule Plug.Conn.Adapter do
   @moduledoc """
   Specification of the connection adapter API implemented by webservers
   """
-  use Behaviour
 
   alias Plug.Conn
   @typep payload :: term
@@ -19,8 +18,8 @@ defmodule Plug.Conn.Adapter do
   test implementation returns the actual body so it can
   be used during testing.
   """
-  defcallback send_resp(payload, Conn.status, Conn.headers, Conn.body) ::
-              {:ok, sent_body :: binary | nil, payload}
+  @callback send_resp(payload, Conn.status, Conn.headers, Conn.body) ::
+            {:ok, sent_body :: binary | nil, payload}
 
   @doc """
   Sends the given status, headers and file as a response
@@ -34,9 +33,9 @@ defmodule Plug.Conn.Adapter do
   test implementation returns the actual body so it can
   be used during testing.
   """
-  defcallback send_file(payload, Conn.status, Conn.headers, file :: binary,
-                        offset :: integer, length :: integer | :all) ::
-              {:ok, sent_body :: binary | nil, payload}
+  @callback send_file(payload, Conn.status, Conn.headers, file :: binary,
+                      offset :: integer, length :: integer | :all) ::
+            {:ok, sent_body :: binary | nil, payload}
 
   @doc """
   Sends the given status, headers as the beginning of
@@ -47,8 +46,8 @@ defmodule Plug.Conn.Adapter do
   test implementation returns the actual body so it can
   be used during testing.
   """
-  defcallback send_chunked(payload, Conn.status, Conn.headers) ::
-              {:ok, sent_body :: binary | nil, payload}
+  @callback send_chunked(payload, Conn.status, Conn.headers) ::
+            {:ok, sent_body :: binary | nil, payload}
 
   @doc """
   Sends a chunk in the chunked response.
@@ -61,8 +60,8 @@ defmodule Plug.Conn.Adapter do
   implementation returns the actual body and payload so
   it can be used during testing.
   """
-  defcallback chunk(payload, Conn.status) ::
-              :ok | {:ok, sent_body :: binary, payload} | {:error, term}
+  @callback chunk(payload, Conn.status) ::
+            :ok | {:ok, sent_body :: binary, payload} | {:error, term}
 
   @doc """
   Reads the request body.
@@ -70,10 +69,10 @@ defmodule Plug.Conn.Adapter do
   Read the docs in `Plug.Conn.read_body/2` for the supported
   options and expected behaviour.
   """
-  defcallback read_req_body(payload, options :: Keyword.t) ::
-              {:ok, data :: binary, payload} |
-              {:more, data :: binary, payload} |
-              {:error, term}
+  @callback read_req_body(payload, options :: Keyword.t) ::
+            {:ok, data :: binary, payload} |
+            {:more, data :: binary, payload} |
+            {:error, term}
 
   @doc """
   Parses a multipart request.
@@ -94,6 +93,6 @@ defmodule Plug.Conn.Adapter do
 
   For the supported options, please read `Plug.Conn.read_body/2` docs.
   """
-  defcallback parse_req_multipart(payload, options :: Keyword.t, fun) ::
-              {:ok, Conn.params, payload} | {:more, Conn.params, payload}
+  @callback parse_req_multipart(payload, options :: Keyword.t, fun) ::
+            {:ok, Conn.params, payload} | {:more, Conn.params, payload}
 end

--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -115,7 +115,6 @@ defmodule Plug.Parsers do
   """
 
   alias Plug.Conn
-  use Behaviour
 
   @doc """
   Attempts to parse the connection's request body given the content-type type
@@ -126,11 +125,11 @@ defmodule Plug.Parsers do
     * `{:error, :too_large, conn}` if the request goes over the given limit
 
   """
-  defcallback parse(Conn.t, type :: binary, subtype :: binary,
-                    headers :: Keyword.t, opts :: Keyword.t) ::
-                    {:ok, Conn.params, Conn.t} |
-                    {:error, :too_large, Conn.t} |
-                    {:next, Conn.t}
+  @callback parse(Conn.t, type :: binary, subtype :: binary,
+                  headers :: Keyword.t, opts :: Keyword.t) ::
+                  {:ok, Conn.params, Conn.t} |
+                  {:error, :too_large, Conn.t} |
+                  {:next, Conn.t}
 
   @behaviour Plug
   @methods ~w(POST PUT PATCH DELETE)

--- a/lib/plug/session/store.ex
+++ b/lib/plug/session/store.ex
@@ -3,8 +3,6 @@ defmodule Plug.Session.Store do
   Specification for session stores.
   """
 
-  use Behaviour
-
   @type sid :: term | nil
   @type cookie :: binary
   @type session :: map
@@ -15,7 +13,7 @@ defmodule Plug.Session.Store do
   The options returned from this function will be given
   to `get/3`, `put/4` and `delete/3`.
   """
-  defcallback init(Plug.opts) :: Plug.opts
+  @callback init(Plug.opts) :: Plug.opts
 
   @doc """
   Parses the given cookie.
@@ -26,7 +24,7 @@ defmodule Plug.Session.Store do
   The session id may be nil in case the cookie does not identify any
   value in the store. The session contents must be a map.
   """
-  defcallback get(Plug.Conn.t, cookie, Plug.opts) :: {sid, session}
+  @callback get(Plug.Conn.t, cookie, Plug.opts) :: {sid, session}
 
   @doc """
   Stores the session associated with given session id.
@@ -34,10 +32,10 @@ defmodule Plug.Session.Store do
   If `nil` is given as id, a new session id should be
   generated and returned.
   """
-  defcallback put(Plug.Conn.t, sid, any, Plug.opts) :: cookie
+  @callback put(Plug.Conn.t, sid, any, Plug.opts) :: cookie
 
   @doc """
   Removes the session associated with given session id from the store.
   """
-  defcallback delete(Plug.Conn.t, sid, Plug.opts) :: :ok
+  @callback delete(Plug.Conn.t, sid, Plug.opts) :: :ok
 end

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -6,7 +6,7 @@ defmodule Plug.SSL do
   header to enable HTTP Strict Transport Security.
 
   Otherwise, the request will be redirected to a corresponding location
-  with the `https` scheme by setting the `location` header of the reponse.
+  with the `https` scheme by setting the `location` header of the response.
   The status code will be 301 if the method of `conn` is `GET` or `HEAD`,
   or 307 in other situations.
 


### PR DESCRIPTION
Hi.

Now I am learning Elixir  and reviewing the sources for `plug` but it should be `@callback` instead by the documentation.

```
Behaviour

This module has been deprecated.

Instead of defcallback, one can simply use @callback. Instead of defmacrocallback, one can simply use @macrocallback. Instead of __behaviour__(:callbacks), one can simply use behaviour_info(:callbacks).
```
