### PR TITLE
Correctly split script_name/path_info when path_info is empty.

### DIFF
--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -70,7 +70,10 @@ defmodule Plug.Router.Utils do
   Forwards requests to another Plug at a new path.
   """
   def forward(%Plug.Conn{path_info: path, script_name: script} = conn, new_path, target, opts) do
-    {base, ^new_path} = Enum.split(path, length(path) - length(new_path))
+    {base, new_path} = case new_path do
+      [] -> {path, []}
+      _ -> Enum.split(path, length(path) - length(new_path))
+    end
     conn = %{conn | path_info: new_path, script_name: script ++ base} |> target.call(opts)
     %{conn | path_info: path, script_name: script}
   end


### PR DESCRIPTION
(I'm not sure if this goes against the "spec" of how `SCRIPT_NAME` and `PATH_INFO` behave in CGI)

From the `Plug.Conn.forward` docs:

> Forwards requests to another Plug. The path_info of the forwarded connection will exclude the portion of the path specified in the call to forward.
> ```
> forward "/users", to: UserRouter
> ```
> Assuming the above code, a request to /users/sign_in will be forwarded to the UserRouter plug, which will receive what it will see as a request to /sign_in.

In plug master a request to /users/sign_in will have `script_name: ["users"], path_info: ["sign_in"]` while one to /users will be forwarded to the UserRouter plug as well, but with `script_name: [], path_info: ["users"]` instead of `script_name: ["users"], path_info: []`.