### PR TITLE
Add raw body to the conn

### DIFF
--- a/lib/plug/parsers/json.ex
+++ b/lib/plug/parsers/json.ex
@@ -36,6 +36,7 @@ defmodule Plug.Parsers.JSON do
   end
 
   defp decode({:ok, body, conn}, decoder) do
+    conn = put_private(conn, :req_body, body)
     case decoder.decode!(body) do
       terms when is_map(terms) ->
         {:ok, terms, conn}


### PR DESCRIPTION
The JSON Parser reads the request body then only stores the parsed/decoded result. If you need the raw body, e.g. for calculation of an HMAC digest to verify the request contents, then you're out of luck. This change stores the raw body of the request as a new private key `req_body`.

This needs tests added, but I wanted to first validate this idea and also get some guidance on how best to test this.