### PR TITLE
Prevent Clobbering Existing Conn.params with Parsing

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -184,8 +184,10 @@ defmodule Plug.Parsers do
 
   defp reduce(conn, [h|t], type, subtype, headers, opts) do
     case h.parse(conn, type, subtype, headers, opts) do
-      {:ok, body, %Conn{query_params: query} = conn} ->
+      {:ok, body, %Conn{params: %Plug.Conn.Unfetched{}, query_params: query} = conn} ->
         %{conn | body_params: body, params: Map.merge(query, body)}
+      {:ok, body, %Conn{params: params, query_params: query} = conn} ->
+        %{conn | body_params: body, params: Enum.reduce([body, query, params], &Map.merge/2)}
       {:next, conn} ->
         reduce(conn, t, type, subtype, headers, opts)
       {:error, :too_large, _conn} ->

--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -185,9 +185,9 @@ defmodule Plug.Parsers do
   defp reduce(conn, [h|t], type, subtype, headers, opts) do
     case h.parse(conn, type, subtype, headers, opts) do
       {:ok, body, %Conn{params: %Plug.Conn.Unfetched{}, query_params: query} = conn} ->
-        %{conn | body_params: body, params: Map.merge(query, body)}
+        %{conn | body_params: body, params: query |> Map.merge(body)}
       {:ok, body, %Conn{params: params, query_params: query} = conn} ->
-        %{conn | body_params: body, params: Enum.reduce([body, query, params], &Map.merge/2)}
+        %{conn | body_params: body, params: params |> Map.merge(query) |> Map.merge(body)}
       {:next, conn} ->
         reduce(conn, t, type, subtype, headers, opts)
       {:error, :too_large, _conn} ->

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -21,6 +21,16 @@ defmodule Plug.ParsersTest do
     assert conn.query_params["foo"] == "bar"
   end
 
+  test "keeps existing params" do
+    conn = %{conn(:post, "/?query=foo", "body=bar") | params: %{"params" => "baz"}}
+    conn = conn
+    |> put_req_header("content-type", "application/x-www-form-urlencoded")
+    |> parse()
+    assert conn.params["query"] == "foo"
+    assert conn.params["body"] == "bar"
+    assert conn.params["params"] == "baz"
+  end
+
   test "keeps existing body params" do
     conn = conn(:post, "/?foo=bar")
     conn = parse(%{conn | body_params: %{"foo" => "baz"}, params: %{"foo" => "baz"}})

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -24,11 +24,19 @@ defmodule Plug.ParsersTest do
   test "keeps existing params" do
     conn = %{conn(:post, "/?query=foo", "body=bar") | params: %{"params" => "baz"}}
     conn = conn
-    |> put_req_header("content-type", "application/x-www-form-urlencoded")
-    |> parse()
+           |> put_req_header("content-type", "application/x-www-form-urlencoded")
+           |> parse()
     assert conn.params["query"] == "foo"
     assert conn.params["body"] == "bar"
     assert conn.params["params"] == "baz"
+  end
+
+  test "parsing prefers body params over query params with existing params" do
+    conn = %{conn(:post, "/?foo=query", "foo=body") | params: %{"foo" => "params"}}
+    conn = conn
+           |> put_req_header("content-type", "application/x-www-form-urlencoded")
+           |> parse()
+    assert conn.params["foo"] == "body"
   end
 
   test "keeps existing body params" do


### PR DESCRIPTION
Was seeing a weird effect when using Plug.Parsers after routing in Phoenix (as part of a `:pipeline`) where the extracted URL params (bindings) were stripped out.  Turns out the parsers were clobbering the existing params.