### PR TITLE
Downcase extensions before checking their mime type

### DIFF
--- a/lib/plug/mime.ex
+++ b/lib/plug/mime.ex
@@ -109,7 +109,7 @@ defmodule Plug.MIME do
   @spec path(Path.t) :: String.t
   def path(path) do
     case Path.extname(path) do
-      "." <> ext -> type(ext)
+      "." <> ext -> type(String.downcase(ext))
       _ -> @default_type
     end
   end

--- a/test/plug/mime_test.exs
+++ b/test/plug/mime_test.exs
@@ -22,6 +22,7 @@ defmodule Plug.MIMETest do
 
   test "path/1" do
     assert path("index.html") == "text/html"
+    assert path("index.HTML") == "text/html"
     assert path("inexistent.filetype") == "application/octet-stream"
     assert path("without-extension") == "application/octet-stream"
   end


### PR DESCRIPTION
We had an issue with Plug.Static returning the default mime type for uppercased image extensions from digital cameras (eg. .JPG). This commit converts the extension to lowercase before checking the type.