### PR TITLE
Plug parsers use `:pass` option now

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -86,7 +86,7 @@ defmodule Plug.Parsers do
 
   This plug will raise `Plug.Parsers.UnsupportedMediaTypeError` by default if
   the request cannot be parsed by any of the given types and the MIME type has
-  not been explicity accepted with the `:accept` option.
+  not been explicity accepted with the `:pass` option.
 
   `Plug.Parsers.RequestTooLargeError` will be raised if the request goes over
   the given limit.


### PR DESCRIPTION
`:accept` is deprecated in 3ed14524c65ccb3116f66ef5fb853b86cf8f30c1