### PR TITLE
Add info/1 to adapters/cowboy.ex

### DIFF
--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -117,6 +117,19 @@ defmodule Plug.Adapters.Cowboy do
     :ranch.child_spec(ref, nb_acceptors, ranch_module, trans_opts, :cowboy_protocol, proto_opts)
   end
 
+  @doc """
+  Returns runtime info about the Ranch listener given by `ref`.
+
+  For more information, see `ranch:get_port/1`, `ranch:get_max_connections/1`, 
+  and `ranch:get_protocol_options/1` in the [Ranch 1.1 
+  documentation](http://ninenines.eu/docs/en/ranch/1.1/manual/ranch/index.html).
+  """
+  def info(ref) do
+    [port:             :ranch.get_port(ref),
+     max_connections:  :ranch.get_max_connections(ref),
+     protocol_options: :ranch.get_protocol_options(ref)]
+  end
+
   ## Helpers
 
   @http_cowboy_options  [port: 4000]

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -303,6 +303,32 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
     :ok = Plug.Adapters.Cowboy.shutdown __MODULE__.HTTPS
   end
 
+  test "returns listener info from ranch" do
+    opts = [port: 8003, ref: :info_test, max_connections: 25]
+    {:ok, _pid} = Plug.Adapters.Cowboy.http __MODULE__, [], opts
+    info = Plug.Adapters.Cowboy.info opts[:ref]
+    # The tests here are in pairs to capture that we're receiving sane information
+    # and that information is the same as what Ranch is reporting.
+    assert info[:port] == 8003
+    assert info[:port] == :ranch.get_port(opts[:ref])
+
+    assert info[:max_connections] == 25
+    assert info[:max_connections] == :ranch.get_max_connections(opts[:ref])
+
+    # Maybe actually set this? It'd be (essentially) re-testing a Ranch call,
+    # so just checking that info/1 sets this should be OK.
+    assert info[:protocol_options] != []
+    assert info[:protocol_options] == :ranch.get_protocol_options(opts[:ref])
+  end
+
+  test "ephemeral port is nonzero after startup" do
+    opts = [port: 0, ref: :ephemeral_test]
+    {:ok, _pid} = Plug.Adapters.Cowboy.http __MODULE__, [], opts
+    info = Plug.Adapters.Cowboy.info opts[:ref]
+    assert info[:port] != 0
+    assert info[:port] == :ranch.get_port(opts[:ref])
+  end
+
   ## Helpers
 
   defp request(:head = verb, path) do


### PR DESCRIPTION
As per @chrismccord's request in phoenixframework/phoenix#1314, this exposes a new function in adapters/cowboy.ex to return information from the underlying listener in order to support the PR phoenixframework/phoenix#1404. However, neither change requires the other to function correctly!