### PR TITLE
Adding notes about lower cased headers

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -26,7 +26,8 @@ defmodule Plug.Conn do
   * `remote_ip` - the IP of the client, example: `{151, 236, 219, 228}`. This field is meant to
     be overwritten by plugs that understand e.g. the `X-Forwarded-For` header or HAProxy's PROXY
     protocol. It defaults to peer's IP.
-  * `req_headers` - the request headers as a list, example: `[{"content-type", "text/plain"}]`
+  * `req_headers` - the request headers as a list, example: `[{"content-type", "text/plain"}]`. 
+    Note all headers will be downcased.
   * `scheme` - the request scheme as an atom, example: `:http`
   * `query_string` - the request query string as a binary, example: `"foo=bar"`
 
@@ -53,7 +54,8 @@ defmodule Plug.Conn do
   * `resp_charset` - the response charset, defaults to "utf-8"
   * `resp_cookies` - the response cookies with their name and options
   * `resp_headers` - the response headers as a dict, by default `cache-control`
-    is set to `"max-age=0, private, must-revalidate"`
+    is set to `"max-age=0, private, must-revalidate"`. Note, response headers 
+    are expected to have lower-case keys.
   * `status` - the response status
 
   Furthermore, the `before_send` field stores callbacks that are invoked


### PR DESCRIPTION
Someone on IRC struggled to find the note at the top of the file regarding headers. I added a note closer to the applicable sections to try and help.


```irc
18:02 <terinjokes> benwilson512: i have a list of headers already, so tried just setting conn.resp_headesr with it
18:02 <terinjokes> found out cowboy isn't case insensitive, and so it set it's own headers duplicating some of mine
18:08 <benwilson512> Ah.
18:09 <jeregrine> terinjokes: hrm which cowboy functions are you using? by default I don't think it sets it own
18:09 <terinjokes> it's setting content-length, server and date if it doesn't see it
18:11 <jeregrine> cowboy always downcases
18:12 <terinjokes> until i manually downcased
18:12 <jeregrine> or so they say
18:12 <jeregrine> is interesting though
18:12 <terinjokes> it was inserting "date" when I had set "Date"
18:14 <jeregrine> ahh yes
18:15 <jeregrine> terinjokes: in the plug conn docs (its not very called it) it does mention all headers req and resp will be or must be lowercased
18:15 <jeregrine> terinjokes: third line http://hexdocs.pm/plug/Plug.Conn.html but yea its not super good spot for it
18:16 <terinjokes> ah, the note on the page i've had open all day
18:17 <terinjokes> i've mostly just been looking at the Request fields and Response fields sections
18:17 <terinjokes> and missed it
```