### PR TITLE
Prevent `body_or_params` from overriding content-type

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -104,8 +104,8 @@ defmodule Plug.Adapters.Test.Conn do
   end
 
   defp body_or_params(params, query, headers) when is_map(params) do
-    headers = :lists.keystore("content-type", 1, headers,
-                              {"content-type", "multipart/mixed; charset: utf-8"})
+    content_type = List.keyfind(headers, "content-type", 0, {"content-type", "multipart/mixed; charset: utf-8"})
+    headers = List.keystore(headers, "content-type", 0, content_type)
     params = Map.merge(Plug.Conn.Query.decode(query), stringify_params(params))
     {"", params, headers}
   end

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -40,9 +40,17 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert {:ok, "", _state} = adapter.read_req_body(state, length: 10)
   end
 
-  test "custom params sets content-type to multipart/mixed" do
+  test "custom params sets content-type to multipart/mixed when content-type is not set" do
     conn = conn(:get, "/", foo: "bar")
     assert conn.req_headers == [{"content-type", "multipart/mixed; charset: utf-8"}]
+  end
+
+  test "custom params does not change content-type when set" do
+    conn =
+      conn(:get, "/", foo: "bar")
+      |> Plug.Conn.put_req_header("content-type", "application/vnd.api+json")
+      |> Plug.Adapters.Test.Conn.conn(:get, "/", foo: "bar")
+    assert conn.req_headers == [{"content-type", "application/vnd.api+json"}]
   end
 
   test "parse_req_multipart/4" do


### PR DESCRIPTION
When passing `Plug.Test.conn` a map, the map is passed down to
`body_or_params`, which always assumed the `content-type` would be
`multipart/mixed; charset: utf-8`. If `content-type` is set in the
`conn`'s headers, it will be preserved. If it is not set, it will
default to `multipart/mixex; charset: utf-8`

`body_or_params` now uses `List.keystore` instead of erlang's
`:lists.keystore`