### PR TITLE
Allow Plug.Session to take http_only option

### DIFF
--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -38,7 +38,7 @@ defmodule Plug.Session do
   alias Plug.Conn
   @behaviour Plug
 
-  @cookie_opts [:domain, :max_age, :path, :secure]
+  @cookie_opts [:domain, :max_age, :path, :secure, :http_only]
 
   def init(opts) do
     store        = Keyword.fetch!(opts, :store) |> convert_store

--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -26,6 +26,7 @@ defmodule Plug.Session do
     * `:max_age` - see `Plug.Conn.put_resp_cookie/4`;
     * `:path` - see `Plug.Conn.put_resp_cookie/4`;
     * `:secure` - see `Plug.Conn.put_resp_cookie/4`;
+    * `:http_only` - see `Plug.Conn.put_resp_cookie/4`;
 
   Additional options can be given to the session store, see the store's
   documentation for the options it accepts.

--- a/test/plug/session_test.exs
+++ b/test/plug/session_test.exs
@@ -17,6 +17,14 @@ defmodule Plug.SessionTest do
     conn = put_session(conn, "foo", "bar")
     conn = send_resp(conn, 200, "")
     assert %{"foobar" => %{value: _, secure: true, path: "some/path"}} = conn.resp_cookies
+    refute conn.resp_cookies["foobar"] |> Map.has_key?(:http_only)
+
+    conn = conn(:get, "/") |> fetch_cookies
+    opts = Plug.Session.init(store: ProcessStore, key: "unsafe_foobar", http_only: false, path: "some/path")
+    conn = Plug.Session.call(conn, opts) |> fetch_session
+    conn = put_session(conn, "foo", "bar")
+    conn = send_resp(conn, 200, "")
+    assert %{"unsafe_foobar" => %{value: _, http_only: false, path: "some/path"}} = conn.resp_cookies
   end
 
   test "put session" do


### PR DESCRIPTION
In reference to https://github.com/elixir-lang/plug/issues/341

I added the `http_only` to the cookie opts, modified the moduledoc to reflect the change, and modified to test to ensure the option was being added.