### PR TITLE
Rename module from Phoenix to Plug

### DIFF
--- a/test/plug/parsers/json_test.exs
+++ b/test/plug/parsers/json_test.exs
@@ -1,4 +1,4 @@
-defmodule Phoenix.Parsers.JSONTest do
+defmodule Plug.Parsers.JSONTest do
   use ExUnit.Case, async: true
   use Plug.Test
 


### PR DESCRIPTION
Assuming this isn't intentional and probably a copy & paste error.