### PR TITLE
Fixed session verification in some situations.

### DIFF
--- a/lib/plug/crypto/message_verifier.ex
+++ b/lib/plug/crypto/message_verifier.ex
@@ -8,7 +8,7 @@ defmodule Plug.Crypto.MessageVerifier do
   tampered with.
   """
 
-  @delimiter "++"
+  @delimiter "##"
 
   @doc """
   Decodes and verifies the encoded binary was not tampared with.

--- a/lib/plug/crypto/message_verifier.ex
+++ b/lib/plug/crypto/message_verifier.ex
@@ -12,7 +12,7 @@ defmodule Plug.Crypto.MessageVerifier do
   Decodes and verifies the encoded binary was not tampared with.
   """
   def verify(binary, secret) when is_binary(binary) and is_binary(secret) do
-    case String.split(binary, "--") do
+    case String.split(binary, "--", parts: 2) do
       [content, digest] when content != "" and digest != "" ->
         if Plug.Crypto.secure_compare(digest(secret, content), digest) do
           decode(content)

--- a/lib/plug/crypto/message_verifier.ex
+++ b/lib/plug/crypto/message_verifier.ex
@@ -14,7 +14,7 @@ defmodule Plug.Crypto.MessageVerifier do
   Decodes and verifies the encoded binary was not tampared with.
   """
   def verify(binary, secret) when is_binary(binary) and is_binary(secret) do
-    case String.split(binary, @delimiter, parts: 2) do
+    case String.split(binary, @delimiter) do
       [content, digest] when content != "" and digest != "" ->
         if Plug.Crypto.secure_compare(digest(secret, content), digest) do
           decode(content)

--- a/lib/plug/crypto/message_verifier.ex
+++ b/lib/plug/crypto/message_verifier.ex
@@ -8,11 +8,13 @@ defmodule Plug.Crypto.MessageVerifier do
   tampered with.
   """
 
+  @delimiter "++"
+
   @doc """
   Decodes and verifies the encoded binary was not tampared with.
   """
   def verify(binary, secret) when is_binary(binary) and is_binary(secret) do
-    case String.split(binary, "--", parts: 2) do
+    case String.split(binary, @delimiter, parts: 2) do
       [content, digest] when content != "" and digest != "" ->
         if Plug.Crypto.secure_compare(digest(secret, content), digest) do
           decode(content)
@@ -29,7 +31,7 @@ defmodule Plug.Crypto.MessageVerifier do
   """
   def sign(binary, secret) when is_binary(binary) and is_binary(secret) do
     encoded = Base.url_encode64(binary)
-    encoded <> "--" <> digest(secret, encoded)
+    encoded <> @delimiter <> digest(secret, encoded)
   end
 
   defp digest(secret, data) do

--- a/test/plug/crypto/message_verifier_test.exs
+++ b/test/plug/crypto/message_verifier_test.exs
@@ -4,7 +4,7 @@ defmodule Plug.Crypto.MessageVerifierTest do
   alias Plug.Crypto.MessageVerifier, as: MV
 
   test "generates a signed message" do
-    [content, encoded] = String.split MV.sign("hello world", "secret"), "--"
+    [content, encoded] = String.split MV.sign("hello world", "secret"), "++"
     assert content |> Base.url_decode64 == {:ok, "hello world"}
     assert byte_size(encoded) == 28
   end
@@ -20,8 +20,8 @@ defmodule Plug.Crypto.MessageVerifierTest do
   end
 
   test "does not verify a tampered message" do
-    [_, encoded] = String.split MV.sign("hello world", "secret"), "--"
+    [_, encoded] = String.split MV.sign("hello world", "secret"), "++"
     content = Base.url_encode64("another world")
-    assert MV.verify(content <> "--" <> encoded, "secret") == :error
+    assert MV.verify(content <> "++" <> encoded, "secret") == :error
   end
 end

--- a/test/plug/crypto/message_verifier_test.exs
+++ b/test/plug/crypto/message_verifier_test.exs
@@ -4,7 +4,7 @@ defmodule Plug.Crypto.MessageVerifierTest do
   alias Plug.Crypto.MessageVerifier, as: MV
 
   test "generates a signed message" do
-    [content, encoded] = String.split MV.sign("hello world", "secret"), "++"
+    [content, encoded] = String.split MV.sign("hello world", "secret"), "##"
     assert content |> Base.url_decode64 == {:ok, "hello world"}
     assert byte_size(encoded) == 28
   end
@@ -20,7 +20,7 @@ defmodule Plug.Crypto.MessageVerifierTest do
   end
 
   test "does not verify a tampered message" do
-    [_, encoded] = String.split MV.sign("hello world", "secret"), "++"
+    [_, encoded] = String.split MV.sign("hello world", "secret"), "##"
     content = Base.url_encode64("another world")
     assert MV.verify(content <> "++" <> encoded, "secret") == :error
   end


### PR DESCRIPTION
We ran into a situation where session cookie cannot be verified. It
happened when `Plug.Crypto.MessageVerifier.digest` returns a string
containing "--" sequence.