### PR TITLE
[WIP] Add `run_plug` test helper

### DIFF
--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -123,4 +123,33 @@ defmodule Plug.Test do
       {key, value}, acc -> put_req_cookie(acc, to_string(key), value)
     end
   end
+
+  @doc """
+  Calls the init and call methods on the plug_module.
+
+  This is the same as:
+
+      opts = SamplePlug.init foo: "bar"
+      SamplePlug.call(conn, opts)
+
+  and allows for writing tests like:
+
+      conn
+      |> run_plug(SamplePlug, foo: "bar")
+      |> run_plug(AnotherPlug)
+
+  """
+  def run_plug(conn, plug_module, plug_opts) do
+    opts = apply(plug_module, :init, [plug_opts])
+    apply(plug_module, :call, [conn, opts])
+  end
+
+  @doc """
+  Calls the init and call methods on the plug module, but without passing
+  any arguments to 'init/1'. See 'run_plug/3'.
+  """
+  def run_plug(conn, plug_module) do
+    opts = apply(plug_module, :init, [])
+    apply(plug_module, :call, [conn, opts])
+  end
 end

--- a/test/plug/session_test.exs
+++ b/test/plug/session_test.exs
@@ -5,25 +5,36 @@ defmodule Plug.SessionTest do
   alias Plug.ProcessStore
 
   test "puts session cookie" do
-    conn = conn(:get, "/") |> fetch_cookies
-    opts = Plug.Session.init(store: ProcessStore, key: "foobar")
-    conn = Plug.Session.call(conn, opts) |> fetch_session
-    conn = send_resp(conn, 200, "")
+    conn =
+      conn(:get, "/")
+      |> fetch_cookies
+      |> run_plug(Plug.Session, store: ProcessStore, key: "foobar")
+      |> fetch_session
+      |> send_resp(200, "")
+
     assert conn.resp_cookies == %{}
 
-    conn = conn(:get, "/") |> fetch_cookies
-    opts = Plug.Session.init(store: ProcessStore, key: "foobar", secure: true, path: "some/path")
-    conn = Plug.Session.call(conn, opts) |> fetch_session
-    conn = put_session(conn, "foo", "bar")
-    conn = send_resp(conn, 200, "")
+    conn =
+      conn(:get, "/")
+      |> fetch_cookies
+      |> run_plug(Plug.Session, store: ProcessStore, key: "foobar", secure: true,
+                  path: "some/path")
+      |> fetch_session
+      |> put_session("foo", "bar")
+      |> send_resp(200, "")
+
     assert %{"foobar" => %{value: _, secure: true, path: "some/path"}} = conn.resp_cookies
     refute conn.resp_cookies["foobar"] |> Map.has_key?(:http_only)
 
-    conn = conn(:get, "/") |> fetch_cookies
-    opts = Plug.Session.init(store: ProcessStore, key: "unsafe_foobar", http_only: false, path: "some/path")
-    conn = Plug.Session.call(conn, opts) |> fetch_session
-    conn = put_session(conn, "foo", "bar")
-    conn = send_resp(conn, 200, "")
+    conn =
+      conn(:get, "/")
+      |> fetch_cookies
+      |> run_plug(Plug.Session, store: ProcessStore, key: "unsafe_foobar",
+                  http_only: false, path: "some/path")
+      |> fetch_session
+      |> put_session("foo", "bar")
+      |> send_resp(200, "")
+
     assert %{"unsafe_foobar" => %{value: _, http_only: false, path: "some/path"}} = conn.resp_cookies
   end
 


### PR DESCRIPTION
While writing tests for plugs, it's pretty common to have code like this:

```elixir
conn = conn(:get, "/")

opts = SamplePlug.init(key: "foobar")
conn = SamplePlug.call(conn, opts)
```

Having to call `init/1` and then `call/2` when running a plug makes it so you can't run a plug as part of an elixir pipeline. Instead, it would be nice to be able to do something like this:

```elixir

conn = 
  conn(:get, "/")
  |> run_plug(SamplePlug, key: "foobar")
  |> run_plug(AnotherPlug)
```

I am curious to hear what you think of this idea. I also included a change to `test/plug/session_test.exs` to show you how this would be used in real tests. If you like this idea, I'd be happy to clean things up and make this a proper pull request.