### PR TITLE
Added Plug.Conn.await_assign_all, added a version of Plug.Conn.await_assign that accepts a key list.

### DIFF
--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -57,6 +57,24 @@ defmodule Plug.ConnTest do
     assert conn.assigns[:hello] == :world
   end
 
+  test "await_assign/3 with list of keys" do
+    conn = conn(:get, "/")
+    conn = async_assign(conn, :one, fn -> :hello end)
+    conn = async_assign(conn, :two, fn -> :world end)
+    conn = await_assign(conn, [:one, :two])
+    assert conn.assigns[:one] == :hello
+    assert conn.assigns[:two] == :world
+  end
+
+  test "await_assign_all/2" do
+    conn = conn(:get, "/")
+    conn = async_assign(conn, :one, fn -> :hello end)
+    conn = async_assign(conn, :two, fn -> :world end)
+    conn = await_assign_all(conn)
+    assert conn.assigns[:one] == :hello
+    assert conn.assigns[:two] == :world
+  end
+
   test "put_status/2" do
     conn = conn(:get, "/")
     assert put_status(conn, nil).status == nil


### PR DESCRIPTION
Allows easier waiting for multiple tasks started with async_assign:

```
conn
|> async_assign(:one, fn -> :hello end)
|> async_assign(:two, fn -> :world end)
|> await_assign_all
```

Or if you want to wait for a list of tasks:

```
conn
|> async_assign(:one, fn -> :hello end)
|> async_assign(:two, fn -> :world end)
|> await_assign([:one, :two])
```

