### PR TITLE
Query string errors should return 400 bad request

### DIFF
--- a/lib/plug/adapters/cowboy/conn.ex
+++ b/lib/plug/adapters/cowboy/conn.ex
@@ -97,7 +97,7 @@ defmodule Plug.Adapters.Cowboy.Conn do
         {:ok, limit, body, req} =
           parse_multipart_body(Request.part_body(req, opts), limit, opts, "")
 
-        Plug.Conn.Utils.validate_utf8!(body, "multipart body")
+        Plug.Conn.Utils.validate_utf8!(body, Plug.Parsers.BadEncodingError, "multipart body")
         parse_multipart(Request.part(req), limit, opts, [{name, body}|acc], callback)
 
       {:file, name, path, %Plug.Upload{} = uploaded} ->

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -26,7 +26,7 @@ defmodule Plug.Conn do
   * `remote_ip` - the IP of the client, example: `{151, 236, 219, 228}`. This field is meant to
     be overwritten by plugs that understand e.g. the `X-Forwarded-For` header or HAProxy's PROXY
     protocol. It defaults to peer's IP.
-  * `req_headers` - the request headers as a list, example: `[{"content-type", "text/plain"}]`. 
+  * `req_headers` - the request headers as a list, example: `[{"content-type", "text/plain"}]`.
     Note all headers will be downcased.
   * `scheme` - the request scheme as an atom, example: `:http`
   * `query_string` - the request query string as a binary, example: `"foo=bar"`
@@ -54,7 +54,7 @@ defmodule Plug.Conn do
   * `resp_charset` - the response charset, defaults to "utf-8"
   * `resp_cookies` - the response cookies with their name and options
   * `resp_headers` - the response headers as a dict, by default `cache-control`
-    is set to `"max-age=0, private, must-revalidate"`. Note, response headers 
+    is set to `"max-age=0, private, must-revalidate"`. Note, response headers
     are expected to have lower-case keys.
   * `status` - the response status
 
@@ -216,6 +216,17 @@ defmodule Plug.Conn do
       * the header key contains uppercase chars
       * the header value contains newlines \n
     """
+  end
+
+  defmodule InvalidQueryError do
+    @moduledoc """
+    Raised when the request string is malformed, for example:
+
+      * the query has bad utf-8 encoding
+      * the query fails to www-form decode
+    """
+
+    defexception message: "query string is invalid", plug_status: 400
   end
 
   alias Plug.Conn
@@ -631,7 +642,7 @@ defmodule Plug.Conn do
 
   def fetch_query_params(%Conn{query_params: %Unfetched{}, params: params,
                                query_string: query_string} = conn, _opts) do
-    Plug.Conn.Utils.validate_utf8!(query_string, "query string")
+    Plug.Conn.Utils.validate_utf8!(query_string, InvalidQueryError, "query string")
     query_params = Plug.Conn.Query.decode(query_string)
 
     case params do

--- a/lib/plug/conn/query.ex
+++ b/lib/plug/conn/query.ex
@@ -64,28 +64,28 @@ defmodule Plug.Conn.Query do
 
   def decode(query, initial) do
     parts = :binary.split(query, "&", [:global])
-    Enum.reduce(Enum.reverse(parts), initial, &decode_string_pair(&1, &2, query))
+    Enum.reduce(Enum.reverse(parts), initial, &decode_string_pair(&1, &2))
   end
 
-  defp decode_string_pair(binary, acc, context) do
+  defp decode_string_pair(binary, acc) do
     current =
       case :binary.split(binary, "=") do
         [key, value] ->
-          {decode_www_form(key, context), decode_www_form(value, context)}
+          {decode_www_form(key), decode_www_form(value)}
         [key] ->
-          {decode_www_form(key, context), nil}
+          {decode_www_form(key), nil}
       end
 
     decode_pair(current, acc)
   end
 
-  defp decode_www_form(value, context) do
+  defp decode_www_form(value) do
     try do
       URI.decode_www_form(value)
     rescue
       ArgumentError ->
-        raise Plug.Parsers.BadEncodingError,
-          message: "invalid www-form encoding on #{context}, got #{value}"
+        raise Plug.Conn.InvalidQueryError,
+          message: "invalid www-form encoding on query-string, got #{value}"
     end
   end
 

--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -268,17 +268,18 @@ defmodule Plug.Conn.Utils do
   @doc """
   Validates the given binary is valid UTF-8.
   """
-  @spec validate_utf8!(binary, binary) :: :ok | no_return
-  def validate_utf8!(<<_ :: utf8, t :: binary>>, context) do
-    validate_utf8!(t, context)
+  @spec validate_utf8!(binary, module, binary) :: :ok | no_return
+  def validate_utf8!(binary, exception, context)
+  def validate_utf8!(<<_ :: utf8, t :: binary>>, exception, context) do
+    validate_utf8!(t, exception, context)
   end
 
-  def validate_utf8!(<<h, _ :: binary>>, context) do
-    raise Plug.Parsers.BadEncodingError,
+  def validate_utf8!(<<h, _ :: binary>>, exception, context) do
+    raise exception,
       message: "invalid UTF-8 on #{context}, got byte #{h}"
   end
 
-  def validate_utf8!(<<>>, _context) do
+  def validate_utf8!(<<>>, _exception, _context) do
     :ok
   end
 

--- a/lib/plug/parsers/urlencoded.ex
+++ b/lib/plug/parsers/urlencoded.ex
@@ -9,7 +9,7 @@ defmodule Plug.Parsers.URLENCODED do
   def parse(conn, "application", "x-www-form-urlencoded", _headers, opts) do
     case Conn.read_body(conn, opts) do
       {:ok, body, conn} ->
-        Plug.Conn.Utils.validate_utf8!(body, "urlencoded body")
+        Plug.Conn.Utils.validate_utf8!(body, Plug.Parsers.BadEncodingError, "urlencoded body")
         {:ok, Plug.Conn.Query.decode(body), conn}
       {:more, _data, conn} ->
         {:error, :too_large, conn}

--- a/test/plug/conn/query_test.exs
+++ b/test/plug/conn/query_test.exs
@@ -134,7 +134,7 @@ defmodule Plug.Conn.QueryTest do
   end
 
   test "raise plug exception on bad www-form" do
-    assert_raise Plug.Parsers.BadEncodingError, fn ->
+    assert_raise Plug.Conn.InvalidQueryError, fn ->
       decode("_utf8=%R2%9P%93")
     end
   end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -554,7 +554,7 @@ defmodule Plug.ConnTest do
 
   test "fetch_query_params/1 with invalid utf-8" do
     conn = conn(:get, "/foo?a=" <> <<139>>)
-    assert_raise Plug.Parsers.BadEncodingError,
+    assert_raise Plug.Conn.InvalidQueryError,
                  "invalid UTF-8 on query string, got byte 139", fn ->
       fetch_query_params(conn)
     end


### PR DESCRIPTION
Changes two instances where query string errors returned 415 instead of 400 like they should.