### PR TITLE
Add missing matching in Plug.Builder.log_halt/4 implementation

### DIFF
--- a/lib/plug/builder.ex
+++ b/lib/plug/builder.ex
@@ -262,7 +262,7 @@ defmodule Plug.Builder do
 
       quote do
         require Logger
-        Logger.unquote(level)(unquote(message))
+        _ = Logger.unquote(level)(unquote(message))
       end
     else
       nil


### PR DESCRIPTION
Gets rid of Dialyzer's `page_controller.ex:1: Expression produces a value of type 'ok' | {'error',_}, but this value is unmatched`  warning on bootstrapped Phoenix application.