### PR TITLE
Use Monotonic time for calculating request latency in Plug.Logger

### DIFF
--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -28,18 +28,21 @@ defmodule Plug.Logger do
       [conn.method, ?\s, conn.request_path]
     end
 
-    before_time = :os.timestamp()
+    before_time = current_time()
 
     Conn.register_before_send(conn, fn conn ->
       Logger.log level, fn ->
-        after_time = :os.timestamp()
-        diff = :timer.now_diff(after_time, before_time)
+        after_time = current_time()
+        diff = (after_time - before_time) |> :erlang.convert_time_unit(:native, :micro_seconds)
+
         [connection_type(conn), ?\s, Integer.to_string(conn.status),
          " in ", formatted_diff(diff)]
       end
       conn
     end)
   end
+
+  defp current_time, do: :erlang.monotonic_time
 
   defp formatted_diff(diff) when diff > 1000, do: [diff |> div(1000) |> Integer.to_string, "ms"]
   defp formatted_diff(diff), do: [diff |> Integer.to_string, "µs"]

--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -28,12 +28,12 @@ defmodule Plug.Logger do
       [conn.method, ?\s, conn.request_path]
     end
 
-    before_time = current_time()
+    start = current_time()
 
     Conn.register_before_send(conn, fn conn ->
       Logger.log level, fn ->
-        after_time = current_time()
-        diff = (after_time - before_time) |> :erlang.convert_time_unit(:native, :micro_seconds)
+        stop = current_time()
+        diff = time_diff(start, stop)
 
         [connection_type(conn), ?\s, Integer.to_string(conn.status),
          " in ", formatted_diff(diff)]
@@ -42,7 +42,14 @@ defmodule Plug.Logger do
     end)
   end
 
-  defp current_time, do: :erlang.monotonic_time
+  # TODO: remove this once Plug supports only Elixir 1.2.
+  if function_exported?(:erlang, :monotonic_time, 0) do
+    defp current_time, do: :erlang.monotonic_time
+    defp time_diff(start, stop), do: (stop - start) |> :erlang.convert_time_unit(:native, :micro_seconds)
+  else
+    defp current_time, do: :os.timestamp()
+    defp time_diff(start, stop), do: :timer.now_diff(stop, start)
+  end
 
   defp formatted_diff(diff) when diff > 1000, do: [diff |> div(1000) |> Integer.to_string, "ms"]
   defp formatted_diff(diff), do: [diff |> Integer.to_string, "µs"]


### PR DESCRIPTION
According to http://erlang.org/doc/apps/erts/time_correction.html#Erlang_Monotonic_Time to Measure Elapsed Time:

> Take timestamps with erlang:monotonic_time/0 and calculate the time difference using ordinary subtraction. The result will be in native time unit. If you want to convert the result to another time unit, you can use erlang:convert_time_unit/3.

> An easier way to do this is to use erlang:monotonic_time/1 with the desired time unit. However, you can then lose accuracy and precision.
