### PR TITLE
Router forwarding must handle paths with url-encoded segments correctly

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -33,7 +33,7 @@ defmodule Plug.Router do
   This means users can easily hook into the router mechanism and add
   behaviour before match, before dispatch or after both.
 
-  To specify private options on `match` that can be used by plugs 
+  To specify private options on `match` that can be used by plugs
   before `dispatch` pass an option with key `:private` containing a map.
   Example:
 
@@ -313,7 +313,7 @@ defmodule Plug.Router do
       match path <> "/*glob", options do
         Plug.Router.Utils.forward(
           var!(conn),
-          var!(glob),
+          Enum.map(var!(glob), &URI.encode_www_form/1),
           @plug_forward_target,
           @plug_forward_opts
         )

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -35,6 +35,10 @@ defmodule Plug.RouterTest do
       exit(:oops)
     end
 
+    match "/fancy_id/:id" do
+      send_resp(conn, 200, id)
+    end
+
     def handle_errors(conn, assigns) do
       # Custom call is always invoked before
       true = Process.get(:plug_forward_call)
@@ -210,6 +214,11 @@ defmodule Plug.RouterTest do
     conn = call(Sample, conn(:get, "/nested/forward"))
     assert conn.resp_body == "forwarded"
     assert conn.path_info == ["nested", "forward"]
+  end
+
+  test "dispatch with forwarding handles urlencoded path segments" do
+    conn = call(Sample, conn(:get, "/nested/forward/fancy_id/%2BANcgj1jZc%2F9O%2B"))
+    assert conn.resp_body == "+ANcgj1jZc/9O+"
   end
 
   test "dispatch with forwarding modifies script_name" do


### PR DESCRIPTION
Stumbled upon this in a project. Proposed fix is quite dirty — IMO `path_info` should not be decoded before forwarding. Unfortunately I don't have a clear idea how to fix this properly.