### PR TITLE
Check conn.host before falling back to www.example.com

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -18,7 +18,7 @@ defmodule Plug.Adapters.Test.Conn do
 
     %Plug.Conn{conn |
       adapter: {__MODULE__, state},
-      host: uri.host || "www.example.com",
+      host: uri.host || conn.host || "www.example.com",
       method: method,
       owner: owner,
       path_info: split_path(uri.path),

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -59,4 +59,20 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert {:ok, params, _} = adapter.parse_req_multipart(state, 1_000_000, fn _ -> :ok end)
     assert params == %{"a" => "b", "c" => [%{"d" => "e"}, "f"]}
   end
+
+  test "use existing conn.host if exists" do
+    conn_with_host = conn(:get, "http://www.elixir-lang.org/")
+    assert conn_with_host.host == "www.elixir-lang.org"
+
+    child_conn = Plug.Adapters.Test.Conn.conn(conn_with_host, :get, "/getting-started/", nil)
+    assert child_conn.host == "www.elixir-lang.org"
+  end
+
+  test "full URL overrides existing conn.host" do
+    conn_with_host = conn(:get, "http://www.elixir-lang.org/")
+    assert conn_with_host.host == "www.elixir-lang.org"
+
+    child_conn = Plug.Adapters.Test.Conn.conn(conn_with_host, :get, "http://www.example.org/", nil)
+    assert child_conn.host == "www.example.org"
+  end
 end


### PR DESCRIPTION
In a possible bug (?), Plug currently resets conn.host to "www.example.com" in tests that just pass a path.

I'm building an application that uses subdomains similarly to \<username\>.github.io or \<chat\>.slack.com, using a similar methodology to http://blog.gazler.com/blog/2015/07/18/subdomains-with-phoenix/. In my Demo.ConnCase, I set the default conn's host, lke so:

```elixir
# test/support/conn_case.ex
  setup do
    {:ok = Ecto.Adapters.SQL.Sandbox.checkout(Demo.Repo),
     conn: %{Phoenix.ConnTest.build_conn() | host: Demo.Endpoint.struct_url.host}}
```

This is correctly passed to my tests, but then is lost when `get`ting the route:

```elixir
defmodule Demo.AppControllerTest do
  use Demo.ConnCase

  test "GET /", %{conn: conn} do
    IO.inspect conn.host
    conn = get conn, "/"
    IO.inspect conn.host
    assert html_response(conn, 200) =~ "Welcome to www.demo.test!"
  end
end
```

```
"www.demo.test"
"www.example.com"

  1) test GET / (Demo.AppControllerTest)
     test/controllers/app_controller_test.exs:4
     Assertion with =~ failed
     code: html_response(conn, 200) =~ "Welcome to www.demo.test!"
     lhs: ...snip... "<h2>Welcome to www.example.com</h2>\n"
     rhs:  "Welcome to www.demo.test"
     stacktrace:
       test/controllers/app_controller_test.exs:8
```

I am able to work around this by explicitly generating a full url instead of using a path, but this requires me to redundantly specify the Demo.Endpoint.struct_url.

```elixir
# test/controllers/app_controller_test.exs
  test "GET /", %{conn: conn} do
    IO.inspect conn.host
    conn = get conn, app_url(Demo.Endpoint.struct_url, :index)
    IO.inspect conn.host
    assert html_response(conn, 200) =~ "Welcome to www.demo.test"
  end
```

```
"www.demo.test"
"www.demo.test"
.

Finished in 0.2 seconds (0.1s on load, 0.07s on tests)
1 test, 0 failures
```

This change causes my tests to pass with just a path, and does not require me to use any workarounds in my application test code.