### PR TITLE
Add :dhfile to normalize absolute path

### DIFF
--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -141,7 +141,7 @@ defmodule Plug.Adapters.Cowboy do
   defp normalize_cowboy_options(cowboy_options, :https) do
     assert_ssl_options(cowboy_options)
     cowboy_options = Keyword.merge @https_cowboy_options, cowboy_options
-    cowboy_options = Enum.reduce [:keyfile, :certfile, :cacertfile], cowboy_options, &normalize_ssl_file(&1, &2)
+    cowboy_options = Enum.reduce [:keyfile, :certfile, :cacertfile, :dhfile], cowboy_options, &normalize_ssl_file(&1, &2)
     cowboy_options = Enum.reduce [:password], cowboy_options, &to_char_list(&2, &1)
     cowboy_options
   end


### PR DESCRIPTION
Deploying with exrm when I add a dhfile option the server crashes because the file path is not correctly resolved. e.g:

```
keyfile: "priv/ssl/key.pem",
certfile: "priv/ssl/cert.pem",
versions: [:"tlsv1.2", :"tlsv1.1", :"tlsv1"],
dhfile: "priv/ssl/dh-params.pem",
```

The options keyfile and certfile works fine but not dhfile.