### PR TITLE
Fix a bug on cached CSRF tokens on mobile Safari

### DIFF
--- a/test/plug/csrf_protection_test.exs
+++ b/test/plug/csrf_protection_test.exs
@@ -206,6 +206,15 @@ defmodule Plug.CSRFProtectionTest do
     refute conn.halted
   end
 
+  test "cache-control header has no-store and no-cache" do
+    [cache_control_header] = conn(:get, "/?token=get")
+    |> call()
+    |> get_resp_header("cache-control")
+
+    assert Regex.match?(~r/no-cache/, cache_control_header) and Regex.match?(~r/no-store/, cache_control_header)
+  end
+
+
   test "non-XHR Javascript GET requests are forbidden" do
     assert_raise InvalidCrossOriginRequestError, fn ->
       conn(:get, "/") |> assign(:content_type, "application/javascript") |> call()


### PR DESCRIPTION
When safari reloads it caches csrf tokens, stop it from doing this!

Here is the original bug: https://github.com/phoenixframework/phoenix/issues/1621
