### PR TITLE
Allow unencoded paths safely to avoid matching errors

### DIFF
--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -70,8 +70,8 @@ defmodule Plug.Router.Utils do
   Forwards requests to another Plug at a new path.
   """
   def forward(%Plug.Conn{path_info: path, script_name: script} = conn, new_path, target, opts) do
-    {base, ^new_path} = Enum.split(path, length(path) - length(new_path))
-    conn = %{conn | path_info: new_path, script_name: script ++ base} |> target.call(opts)
+    {base, split_path} = Enum.split(path, length(path) - length(new_path))
+    conn = %{conn | path_info: split_path, script_name: script ++ base} |> target.call(opts)
     %{conn | path_info: path, script_name: script}
   end
 

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -221,6 +221,11 @@ defmodule Plug.RouterTest do
     assert conn.resp_body == "+ANcgj1jZc/9O+"
   end
 
+  test "dispatch with forwarding handles un-urlencoded path segments" do
+    conn = call(Sample, conn(:get, "/nested/forward/fancy_id/+ANcgj1jZc9O+"))
+    assert conn.resp_body == "+ANcgj1jZc9O+"
+  end
+
   test "dispatch with forwarding modifies script_name" do
     conn = call(Sample, conn(:get, "/nested/forward/script_name"))
     assert conn.resp_body == "nested,forward"


### PR DESCRIPTION
This PR is a minor change to fix #391. It's the simplest option as far as I can tell (but I'm new to the codebase so I might be missing something). If anyone has any suggestions, let me know.

I added a test to cover the issue which fails when the fix is not applied, and all other tests still pass after the fix is applied.

There's a slightly lower amount of verification due to the removal of the pin, but the only option to keep that is to do something like:

```elixir
unless split_path == new_path or split_path == Enum.map(new_path, &URI.decode_www_form/1) do
  raise Something
end
```

I feel this has too much potential overhead for what the gain is, so opted for just removing the pin and leaving like that (also note the snippet above is example, it'd be cleaner if included).