### PR TITLE
`Test.Conn` to stop appending chunks after the empty string is sent.

### DIFF
--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -75,4 +75,13 @@ defmodule Plug.Adapters.Test.ConnTest do
     child_conn = Plug.Adapters.Test.Conn.conn(conn_with_host, :get, "http://www.example.org/", nil)
     assert child_conn.host == "www.example.org"
   end
+
+  test "chunked req_body stops appending req_body after an empty chunk" do
+    with %Plug.Conn{} = conn <- conn(:get, "/"),
+         %Plug.Conn{state: :chunked, status: 200} = conn <- Plug.Conn.send_chunked(conn, 200),
+         {:ok, conn} <- Plug.Conn.chunk(conn, "Hello"),
+         {:ok, conn} <- Plug.Conn.chunk(conn, ""),
+         {:ok, conn} <- Plug.Conn.chunk(conn, "World"),
+    do: assert conn.resp_body == "Hello"
+  end
 end


### PR DESCRIPTION
I hope it is not too forward of me to up and propose a PR without talking about it with you all first, but I was all excited and would love feedback even if it is not considered an issue worth fixing.

Regarding issue https://github.com/elixir-lang/plug/issues/394

Sending a chunk with an empty body kills the connection, however Test.Conn would
still append chunk bodies in test. This PR adds state to track if chunking
is still ongoing and prevents appending the chunks to the response body if  the
connection has been terminated by sending a chunk with an empty body.