### PR TITLE
ensure that Conn's public API is consistent about not sending empty chunks

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -422,6 +422,7 @@ defmodule Plug.Conn do
   otherwise `{:error, reason}`.
   """
   @spec chunk(t, body) :: {:ok, t} | {:error, term} | no_return
+  def chunk(%Conn{state: :chunked} = conn, ""), do: {:ok, conn}
   def chunk(%Conn{adapter: {adapter, payload}, state: :chunked} = conn, chunk) do
     case adapter.chunk(payload, chunk) do
       :ok                  -> {:ok, conn}


### PR DESCRIPTION
Regarding Issue: https://github.com/elixir-lang/plug/issues/394

In light of the conversation around handling chunking when sending the empty chunk that came with this PR, https://github.com/elixir-lang/plug/pull/395, we decided it would be best to ensure that Conn has a consistent public API of not sending empty chunks despite however the underlying http adapter would handle them.