### PR TITLE
Update parenthetical to match preceding acronym

### DIFF
--- a/lib/plug/csrf_protection.ex
+++ b/lib/plug/csrf_protection.ex
@@ -68,7 +68,7 @@ defmodule Plug.CSRFProtection do
     @moduledoc "Error raised when CSRF token is invalid."
 
     message =
-      "invalid CSRF (Cross Site Forgery Protection) token, make sure all "
+      "invalid CSRF (Cross Site Request Forgery) token, make sure all "
       <> "requests include a valid '_csrf_token' param or 'x-csrf-token' header"
 
     defexception message: message, plug_status: 403


### PR DESCRIPTION
Just a small change I noticed that might be clearer to the user. If we desired to include the copy "protection", we might add it after the parenthetical.

❤️ Thoughts?