### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -14,7 +14,7 @@ defmodule Plug.Adapters.Test.Conn do
 
     {body, params, req_headers} = body_or_params(body_or_params, query, conn.req_headers)
     state = %{method: method, params: params, req_body: body,
-              chunks: nil, ref: make_ref, owner: owner}
+              chunks: nil, ref: make_ref(), owner: owner}
 
     %Plug.Conn{conn |
       adapter: {__MODULE__, state},

--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -135,7 +135,7 @@ defmodule Plug.Parsers do
   @methods ~w(POST PUT PATCH DELETE)
 
   def init(opts) do
-    parsers = Keyword.get(opts, :parsers) || raise_missing_parsers
+    parsers = Keyword.get(opts, :parsers) || raise_missing_parsers()
 
     opts
     |> Keyword.put(:parsers, convert_parsers(parsers))

--- a/lib/plug/request_id.ex
+++ b/lib/plug/request_id.ex
@@ -45,8 +45,8 @@ defmodule Plug.RequestId do
 
   defp get_request_id(conn, header) do
     case Conn.get_req_header(conn, header) do
-      []      -> {conn, generate_request_id}
-      [val|_] -> if valid_request_id?(val), do: {conn, val}, else: {conn, generate_request_id}
+      []      -> {conn, generate_request_id()}
+      [val|_] -> if valid_request_id?(val), do: {conn, val}, else: {conn, generate_request_id()}
     end
   end
 

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -68,7 +68,7 @@ defmodule Plug.Test do
       response ->
         case receive_resp(ref) do
           :no_resp ->
-            send(self, {ref, response})
+            send(self(), {ref, response})
             response
           _otherwise ->
             raise "a response for the given connection has been sent more than once"

--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,8 @@ defmodule Plug.Mixfile do
     [app: :plug,
      version: @version,
      elixir: "~> 1.0",
-     deps: deps,
-     package: package,
+     deps: deps(),
+     package: package(),
      description: "A specification and conveniences for composable " <>
                   "modules between web applications",
      name: "Plug",


### PR DESCRIPTION
They're all "local 0-arity function without parens" warnings.