### PR TITLE
Makes use of Map instead of Dict

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -53,7 +53,7 @@ defmodule Plug.Conn do
     to nil after the response is set, except for test connections.
   * `resp_charset` - the response charset, defaults to "utf-8"
   * `resp_cookies` - the response cookies with their name and options
-  * `resp_headers` - the response headers as a map, by default `cache-control`
+  * `resp_headers` - the response headers as a map or a list of tuples, by default `cache-control`
     is set to `"max-age=0, private, must-revalidate"`. Note, response headers
     are expected to have lower-case keys.
   * `status` - the response status

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -53,7 +53,7 @@ defmodule Plug.Conn do
     to nil after the response is set, except for test connections.
   * `resp_charset` - the response charset, defaults to "utf-8"
   * `resp_cookies` - the response cookies with their name and options
-  * `resp_headers` - the response headers as a map or a list of tuples, by default `cache-control`
+  * `resp_headers` - the response headers as a list of tuples, by default `cache-control`
     is set to `"max-age=0, private, must-revalidate"`. Note, response headers
     are expected to have lower-case keys.
   * `status` - the response status

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -53,7 +53,7 @@ defmodule Plug.Conn do
     to nil after the response is set, except for test connections.
   * `resp_charset` - the response charset, defaults to "utf-8"
   * `resp_cookies` - the response cookies with their name and options
-  * `resp_headers` - the response headers as a dict, by default `cache-control`
+  * `resp_headers` - the response headers as a map, by default `cache-control`
     is set to `"max-age=0, private, must-revalidate"`. Note, response headers
     are expected to have lower-case keys.
   * `status` - the response status
@@ -65,7 +65,7 @@ defmodule Plug.Conn do
 
   ## Connection fields
 
-  * `assigns` - shared user data as a dict
+  * `assigns` - shared user data as a map
   * `owner` - the Elixir process that owns the connection
   * `halted` - the boolean status on whether the pipeline was halted
   * `secret_key_base` - a secret key used to verify and encrypt cookies.
@@ -84,7 +84,7 @@ defmodule Plug.Conn do
   These fields are reserved for libraries/framework usage.
 
   * `adapter` - holds the adapter information in a tuple
-  * `private` - shared library data as a dict
+  * `private` - shared library data as a map
 
   ## Protocols
 

--- a/lib/plug/conn/query.ex
+++ b/lib/plug/conn/query.ex
@@ -163,10 +163,10 @@ defmodule Plug.Conn.Query do
   defp assign_list(t, value),  do: assign_parts(t, value, %{})
 
   @doc """
-  Encodes the given map.
+  Encodes the given map or list of tuples.
   """
-  def encode(map, encoder \\ &to_string/1) do
-    IO.iodata_to_binary encode_pair("", map, encoder)
+  def encode(kv, encoder \\ &to_string/1) do
+    IO.iodata_to_binary encode_pair("", kv, encoder)
   end
 
   # covers structs
@@ -176,12 +176,12 @@ defmodule Plug.Conn.Query do
 
   # covers maps
   defp encode_pair(parent_field, %{} = map, encoder) do
-    encode_map(map, parent_field, encoder)
+    encode_kv(map, parent_field, encoder)
   end
 
   # covers keyword lists
   defp encode_pair(parent_field, list, encoder) when is_list(list) and is_tuple(hd(list)) do
-    encode_map(Enum.uniq(list, &elem(&1, 0)), parent_field, encoder)
+    encode_kv(Enum.uniq(list, &elem(&1, 0)), parent_field, encoder)
   end
 
   # covers non-keyword lists
@@ -201,8 +201,8 @@ defmodule Plug.Conn.Query do
     [field, ?=|encode_value(value, encoder)]
   end
 
-  defp encode_map(map, parent_field, encoder) do
-    prune Enum.flat_map map, fn
+  defp encode_kv(kv, parent_field, encoder) do
+    prune Enum.flat_map kv, fn
       {_, value} when value in [%{}, []] ->
         []
       {field, value} ->

--- a/lib/plug/conn/query.ex
+++ b/lib/plug/conn/query.ex
@@ -25,7 +25,7 @@ defmodule Plug.Conn.Query do
       iex> decode("foo[]=bar&foo[]=baz")["foo"]
       ["bar", "baz"]
 
-  Dicts can be encoded:
+  Maps can be encoded:
 
       iex> encode(%{foo: "bar", baz: "bat"})
       "baz=bat&foo=bar"
@@ -163,10 +163,10 @@ defmodule Plug.Conn.Query do
   defp assign_list(t, value),  do: assign_parts(t, value, %{})
 
   @doc """
-  Encodes the given dict.
+  Encodes the given map.
   """
-  def encode(dict, encoder \\ &to_string/1) do
-    IO.iodata_to_binary encode_pair("", dict, encoder)
+  def encode(map, encoder \\ &to_string/1) do
+    IO.iodata_to_binary encode_pair("", map, encoder)
   end
 
   # covers structs
@@ -176,12 +176,12 @@ defmodule Plug.Conn.Query do
 
   # covers maps
   defp encode_pair(parent_field, %{} = map, encoder) do
-    encode_dict(map, parent_field, encoder)
+    encode_map(map, parent_field, encoder)
   end
 
   # covers keyword lists
   defp encode_pair(parent_field, list, encoder) when is_list(list) and is_tuple(hd(list)) do
-    encode_dict(Enum.uniq(list, &elem(&1, 0)), parent_field, encoder)
+    encode_map(Enum.uniq(list, &elem(&1, 0)), parent_field, encoder)
   end
 
   # covers non-keyword lists
@@ -201,8 +201,8 @@ defmodule Plug.Conn.Query do
     [field, ?=|encode_value(value, encoder)]
   end
 
-  defp encode_dict(dict, parent_field, encoder) do
-    prune Enum.flat_map dict, fn
+  defp encode_map(map, parent_field, encoder) do
+    prune Enum.flat_map map, fn
       {_, value} when value in [%{}, []] ->
         []
       {field, value} ->

--- a/test/plug/conn/query_test.exs
+++ b/test/plug/conn/query_test.exs
@@ -128,7 +128,7 @@ defmodule Plug.Conn.QueryTest do
            "foo=%2Fbar%2Fbar"
   end
 
-  test "encode ignores empty dicts" do
+  test "encode ignores empty map" do
     assert encode(%{filter: %{}, foo: "bar", baz: "bat"}) == "baz=bat&foo=bar"
     assert encode(%{filter: [], foo: "bar", baz: "bat"}) == "baz=bat&foo=bar"
   end

--- a/test/plug/conn/query_test.exs
+++ b/test/plug/conn/query_test.exs
@@ -128,7 +128,7 @@ defmodule Plug.Conn.QueryTest do
            "foo=%2Fbar%2Fbar"
   end
 
-  test "encode ignores empty map" do
+  test "encode ignores empty maps or lists" do
     assert encode(%{filter: %{}, foo: "bar", baz: "bat"}) == "baz=bat&foo=bar"
     assert encode(%{filter: [], foo: "bar", baz: "bat"}) == "baz=bat&foo=bar"
   end


### PR DESCRIPTION
Changes `Dict` instances to `Map` in the following files:
- [query.ex](https://github.com/elixir-lang/plug/blob/0b387966d2f21cf050ca666f328864b546b4e754/lib/plug/conn/query.ex)
- [conn.ex](https://github.com/elixir-lang/plug/blob/91d0f698a67a4b0c5e62a8631693b91a482311de/lib/plug/conn.ex)

Also, renamed private function `encode_dict` to `encode_map` instead. :)