### PR TITLE
Make private functions handle_errors/2, dispath/2, & match/2 public

### DIFF
--- a/lib/plug/error_handler.ex
+++ b/lib/plug/error_handler.ex
@@ -45,7 +45,8 @@ defmodule Plug.ErrorHandler do
     quote location: :keep do
       @before_compile Plug.ErrorHandler
 
-      defp handle_errors(conn, assigns) do
+      @doc false
+      def handle_errors(conn, assigns) do
         Plug.Conn.send_resp(conn, conn.status, "Something went wrong")
       end
 

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -168,11 +168,13 @@ defmodule Plug.Router do
 
       use Plug.Builder, unquote(opts)
 
-      defp match(conn, _opts) do
+      @doc false
+      def match(conn, _opts) do
         do_match(conn, conn.method, Enum.map(conn.path_info, &URI.decode/1), conn.host)
       end
 
-      defp dispatch(%Plug.Conn{assigns: assigns} = conn, _opts) do
+      @doc false
+      def dispatch(%Plug.Conn{assigns: assigns} = conn, _opts) do
         Map.get(conn.private, :plug_route).(conn)
       end
 


### PR DESCRIPTION
In Elixir v1.4.0-dev overridable private functions is deprecated and produces a warning message. This PR makes the 3 private overridable functions public.   