### PR TITLE
Polish the error message for the Plug.ParseError exception

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -36,10 +36,9 @@ defmodule Plug.Parsers do
 
     defexception exception: nil, plug_status: 400
 
-    def message(exception) do
-      exception = exception.exception
-      "malformed request, got #{inspect exception.__struct__} " <>
-        "with message #{Exception.message(exception)}"
+    def message(%{exception: exception}) do
+      "malformed request, a #{inspect exception.__struct__} exception was raised " <>
+        "with message: #{inspect(Exception.message(exception))}"
     end
   end
 

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -303,8 +303,8 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
        {"Content-Length", byte_size(multipart)}]
 
     assert {500, _, body} = request :post, "/multipart", headers, multipart
-    assert body =~ "malformed request, got MatchError with message " <>
-      "no match of right hand side value: false"
+    assert body =~ "malformed request, a MatchError exception was raised with message: " <>
+      ~s("no match of right hand side value: false")
   end
 
   def https(conn) do

--- a/test/plug/parsers/json_test.exs
+++ b/test/plug/parsers/json_test.exs
@@ -61,8 +61,8 @@ defmodule Plug.Parsers.JSONTest do
   end
 
   test "raises ParseError with malformed JSON" do
-    exception = assert_raise Plug.Parsers.ParseError,
-                             ~r/malformed request, got RuntimeError with message oops/, fn ->
+    message = ~s(malformed request, a RuntimeError exception was raised with message: "oops")
+    exception = assert_raise Plug.Parsers.ParseError, message, fn ->
       json_conn("invalid json") |> parse()
     end
     assert Plug.Exception.status(exception) == 400


### PR DESCRIPTION
We weren't using double quotes around the message raised by the exception that `ParseError` is wrapping, and IMO this was a bit confusing to read. I took advantage of the changes to refactor the code very very slightly. Let me know what you think :)