### PR TITLE
Correct the error message for the Plug.ParseError exception

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -38,7 +38,7 @@ defmodule Plug.Parsers do
 
     def message(%{exception: exception}) do
       "malformed request, a #{inspect exception.__struct__} exception was raised " <>
-        "with message: #{inspect(Exception.message(exception))}"
+        "with message #{inspect(Exception.message(exception))}"
     end
   end
 

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -303,7 +303,7 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
        {"Content-Length", byte_size(multipart)}]
 
     assert {500, _, body} = request :post, "/multipart", headers, multipart
-    assert body =~ "malformed request, a MatchError exception was raised with message: " <>
+    assert body =~ "malformed request, a MatchError exception was raised with message " <>
       ~s("no match of right hand side value: false")
   end
 

--- a/test/plug/parsers/json_test.exs
+++ b/test/plug/parsers/json_test.exs
@@ -61,7 +61,7 @@ defmodule Plug.Parsers.JSONTest do
   end
 
   test "raises ParseError with malformed JSON" do
-    message = ~s(malformed request, a RuntimeError exception was raised with message: "oops")
+    message = ~s(malformed request, a RuntimeError exception was raised with message "oops")
     exception = assert_raise Plug.Parsers.ParseError, message, fn ->
       json_conn("invalid json") |> parse()
     end


### PR DESCRIPTION
We don't use colon with `inspect`ed error messages.