### PR TITLE
Replace AES-CBC with AES-GCM and HMAC-SHA-1 with HMAC-SHA-256.

### DIFF
--- a/lib/plug/crypto/message_encryptor.ex
+++ b/lib/plug/crypto/message_encryptor.ex
@@ -3,8 +3,8 @@ defmodule Plug.Crypto.MessageEncryptor do
   `MessageEncryptor` is a simple way to encrypt values which get stored
   somewhere you don't trust.
 
-  The cipher text and initialization vector are base64 encoded and
-  returned to you.
+  The encrypted key, initialization vector, cipher text, and cipher tag
+  are base64url encoded and returned to you.
 
   This can be used in situations similar to the `MessageVerifier`, but where
   you don't want users to be able to determine the value of the payload.
@@ -19,76 +19,264 @@ defmodule Plug.Crypto.MessageEncryptor do
       sign_secret = KeyGenerator.generate(secret_key_base, encrypted_signed_cookie_salt)
 
       data = "José"
-      encrypted = MessageEncryptor.encrypt_and_sign(data, secret, sign_secret)
-      decrypted = MessageEncryptor.verify_and_decrypt(encrypted, secret, sign_secret)
-      decrypted # => "José"
+      encrypted = MessageEncryptor.encrypt(data, secret, sign_secret)
+      decrypted = MessageEncryptor.decrypt(encrypted, secret, sign_secret)
+      decrypted # => {:ok, "José"}
   """
 
   alias Plug.Crypto.MessageVerifier
 
   @doc """
-  Encrypts and signs a message.
+  Encrypts a message using authenticated encryption.
   """
-  def encrypt_and_sign(message, secret, sign_secret, cipher \\ :aes_cbc256)
+  def encrypt(message, secret, sign_secret)
       when is_binary(message) and is_binary(secret) and is_binary(sign_secret) do
-    iv = :crypto.strong_rand_bytes(16)
-
-    message
-    |> pad_message
-    |> encrypt(cipher, secret, iv)
-    |> Base.encode64()
-    |> Kernel.<>("--")
-    |> Kernel.<>(Base.encode64(iv))
-    |> MessageVerifier.sign(sign_secret)
+    aes128_gcm_encrypt(message, secret, sign_secret)
   end
 
   @doc """
+  Decrypts a message using authenticated encryption.
+  """
+  def decrypt(encrypted, secret, sign_secret)
+      when is_binary(encrypted) and is_binary(secret) and is_binary(sign_secret) do
+    aes128_gcm_decrypt(encrypted, secret, sign_secret)
+  end
+
+  ## Deprecated API
+
+  @doc """
+  WARNING: This function is deprecated in favor of `encrypt/3`.
+  Encrypts and signs a message.
+  """
+  def encrypt_and_sign(message, secret, sign_secret, cipher \\ nil)
+      when is_binary(message) and is_binary(secret) and is_binary(sign_secret) do
+    # TODO: Deprecate after backwards compatibility period
+    # IO.puts :stderr, "warning: `Plug.Crypto.MessageEncryptor.encrypt_and_sign/4` is deprecated," <>
+    #                  "please use `encrypt/3` instead\n" <> Exception.format_stacktrace
+    case cipher do
+      nil ->
+        encrypt(message, secret, sign_secret)
+      :aes_cbc256 ->
+        aes256_cbc_hmac_sha1_encrypt(message, secret, sign_secret)
+      _ ->
+        iv = :crypto.strong_rand_bytes(16)
+
+        message
+        |> pkcs7_pad()
+        |> encrypt_legacy(cipher, secret, iv)
+        |> Base.encode64()
+        |> Kernel.<>("--")
+        |> Kernel.<>(Base.encode64(iv))
+        |> MessageVerifier.sign(sign_secret)
+    end
+  end
+
+  @doc """
+  WARNING: This function is deprecated in favor of `decrypt/3`.
   Decrypts and verifies a message.
 
   We need to verify the message in order to avoid padding attacks.
   Reference: http://www.limited-entropy.com/padding-oracle-attacks
   """
-  def verify_and_decrypt(encrypted, secret, sign_secret, cipher \\ :aes_cbc256)
+  def verify_and_decrypt(encrypted, secret, sign_secret, cipher \\ nil)
       when is_binary(encrypted) and is_binary(secret) and is_binary(sign_secret) do
-    case MessageVerifier.verify(encrypted, sign_secret) do
-      {:ok, verified} ->
-        [encrypted, iv] = String.split(verified, "--")
-        case Base.decode64(encrypted) do
-          {:ok, encrypted} ->
-            case Base.decode64(iv) do
-              {:ok, iv} ->
-                encrypted |> decrypt(cipher, secret, iv) |> unpad_message
+    # TODO: Deprecate after backwards compatibility period
+    # IO.puts :stderr, "warning: `Plug.Crypto.MessageEncryptor.verify_and_decrypt/4` is deprecated," <>
+    #                  "please use `decrypt/3` instead\n" <> Exception.format_stacktrace
+    case cipher do
+      nil ->
+        if String.contains?(encrypted, ".") do
+          decrypt(encrypted, secret, sign_secret)
+        else
+          verify_and_decrypt(encrypted, secret, sign_secret, :aes_cbc256)
+        end
+      :aes_cbc256 ->
+        aes256_cbc_hmac_sha1_decrypt(encrypted, secret, sign_secret)
+      _ ->
+        case MessageVerifier.verify(encrypted, sign_secret) do
+          {:ok, verified} ->
+            [encrypted, iv] = String.split(verified, "--")
+            case Base.decode64(encrypted) do
+              {:ok, encrypted} ->
+                case Base.decode64(iv) do
+                  {:ok, iv} ->
+                    encrypted |> decrypt_legacy(cipher, secret, iv) |> pkcs7_unpad
+                  :error ->
+                    :error
+                end
               :error ->
                 :error
             end
           :error ->
             :error
         end
-      :error ->
+    end
+  end
+
+  ## Authenticated Encryption Algorithms
+
+  # Encrypts and authenticates a message using AES128-CBC mode
+  # with HMAC-SHA-1 for the authentication code.
+  defp aes256_cbc_hmac_sha1_encrypt(plain_text, secret, sign_secret)
+      when bit_size(secret) > 256,
+    do: aes256_cbc_hmac_sha1_encrypt(plain_text, binary_part(secret, 0, 32), sign_secret)
+  defp aes256_cbc_hmac_sha1_encrypt(plain_text, secret, sign_secret)
+      when is_binary(plain_text)
+      and bit_size(secret) in [128, 192, 256]
+      and is_binary(sign_secret) do
+    iv = :crypto.strong_rand_bytes(16)
+    cipher_text = :crypto.block_encrypt(:aes_cbc256, secret, iv, pkcs7_pad(plain_text))
+    encode_legacy_token(sign_secret, iv, cipher_text)
+  end
+
+  # Verifies and decrypts a message using AES128-CBC mode
+  # with HMAC-SHA-1 for the authentication code.
+  # 
+  # Decryption will never be performed prior to verification.
+  defp aes256_cbc_hmac_sha1_decrypt(cipher_text, secret, sign_secret)
+      when bit_size(secret) > 256,
+    do: aes256_cbc_hmac_sha1_decrypt(cipher_text, binary_part(secret, 0, 32), sign_secret)
+  defp aes256_cbc_hmac_sha1_decrypt(cipher_text, secret, sign_secret)
+      when is_binary(cipher_text)
+      and bit_size(secret) === 256
+      and is_binary(sign_secret) do
+    case decode_legacy_token(cipher_text, sign_secret) do
+      {"A256CBC-HS1", _encrypted_key, iv, cipher_text, cipher_tag}
+          when bit_size(iv) === 128 and bit_size(cipher_tag) === 160 ->
+        key = secret
+        :crypto.block_decrypt(:aes_cbc256, key, iv, cipher_text)
+        |> case do
+          plain_text when is_binary(plain_text) ->
+            pkcs7_unpad(plain_text)
+          _ ->
+            :error
+        end
+      _ ->
         :error
     end
   end
 
-  defp encrypt(message, cipher, secret, iv) do
-    :crypto.block_encrypt(cipher, trim_secret(secret), iv, message)
+  # Encrypts and authenticates a message using AES128-GCM mode.
+  # 
+  # A random 128-bit content encryption key (CEK) is generated for
+  # every message which is then encrypted with `aes_gcm_key_wrap/3`.
+  defp aes128_gcm_encrypt(plain_text, secret, sign_secret)
+      when bit_size(secret) > 256,
+    do: aes128_gcm_encrypt(plain_text, binary_part(secret, 0, 32), sign_secret)
+  defp aes128_gcm_encrypt(plain_text, secret, sign_secret)
+      when is_binary(plain_text)
+      and bit_size(secret) in [128, 192, 256]
+      and is_binary(sign_secret) do
+    key = :crypto.strong_rand_bytes(16)
+    iv = :crypto.strong_rand_bytes(12)
+    aad = "A128GCM"
+    {cipher_text, cipher_tag} = :crypto.block_encrypt(:aes_gcm, key, iv, {aad, plain_text})
+    encrypted_key = aes_gcm_key_wrap(key, secret, sign_secret)
+    encode_token(aad, encrypted_key, iv, cipher_text, cipher_tag)
   end
 
-  defp decrypt(encrypted, cipher, secret, iv) do
-    :crypto.block_decrypt(cipher, trim_secret(secret), iv, encrypted)
+  # Verifies and decrypts a message using AES128-GCM mode.
+  # 
+  # Decryption will never be performed prior to verification.
+  # 
+  # The encrypted content encryption key (CEK) is decrypted
+  # with `aes_gcm_key_unwrap/3`.
+  defp aes128_gcm_decrypt(cipher_text, secret, sign_secret)
+      when bit_size(secret) > 256,
+    do: aes128_gcm_decrypt(cipher_text, binary_part(secret, 0, 32), sign_secret)
+  defp aes128_gcm_decrypt(cipher_text, secret, sign_secret)
+      when is_binary(cipher_text)
+      and bit_size(secret) in [128, 192, 256]
+      and is_binary(sign_secret) do
+    case decode_token(cipher_text) do
+      {aad = "A128GCM", encrypted_key, iv, cipher_text, cipher_tag}
+          when bit_size(iv) === 96 and bit_size(cipher_tag) === 128 ->
+        encrypted_key
+        |> aes_gcm_key_unwrap(secret, sign_secret)
+        |> case do
+          {:ok, key} ->
+            :crypto.block_decrypt(:aes_gcm, key, iv, {aad, cipher_text, cipher_tag})
+          _ ->
+            :error
+        end
+        |> case do
+          plain_text when is_binary(plain_text) ->
+            {:ok, plain_text}
+          _ ->
+            :error
+        end
+      _ ->
+        :error
+    end
   end
 
-  defp pad_message(msg) do
-    bytes_remaining = rem(byte_size(msg), 16)
+  # Wraps a decrypted content encryption key (CEK) with secret and
+  # sign_secret using AES GCM mode.
+  # 
+  # See: https://tools.ietf.org/html/rfc7518#section-4.7
+  defp aes_gcm_key_wrap(cek, secret, sign_secret)
+      when bit_size(secret) > 256,
+    do: aes_gcm_key_wrap(cek, binary_part(secret, 0, 32), sign_secret)
+  defp aes_gcm_key_wrap(cek, secret, sign_secret)
+      when bit_size(cek) in [128, 192, 256]
+      and bit_size(secret) in [128, 192, 256]
+      and is_binary(sign_secret) do
+    iv = :crypto.strong_rand_bytes(12)
+    {cipher_text, cipher_tag} = :crypto.block_encrypt(:aes_gcm, secret, iv, {sign_secret, cek})
+    cipher_text <> cipher_tag <> iv
+  end
+
+  # Unwraps an encrypted content encryption key (CEK) with secret and
+  # sign_secret using AES GCM mode.
+  # 
+  # See: https://tools.ietf.org/html/rfc7518#section-4.7
+  defp aes_gcm_key_unwrap(wrapped_cek, secret, sign_secret)
+      when bit_size(secret) > 256,
+    do: aes_gcm_key_unwrap(wrapped_cek, binary_part(secret, 0, 32), sign_secret)
+  defp aes_gcm_key_unwrap(wrapped_cek, secret, sign_secret)
+      when bit_size(secret) in [128, 192, 256]
+      and is_binary(sign_secret) do
+    wrapped_cek
+    |> case do
+      << cipher_text :: 128-bitstring, cipher_tag :: 128-bitstring, iv :: 96-bitstring >> ->
+        :crypto.block_decrypt(:aes_gcm, secret, iv, {sign_secret, cipher_text, cipher_tag})
+      << cipher_text :: 192-bitstring, cipher_tag :: 128-bitstring, iv :: 96-bitstring >> ->
+        :crypto.block_decrypt(:aes_gcm, secret, iv, {sign_secret, cipher_text, cipher_tag})
+      << cipher_text :: 256-bitstring, cipher_tag :: 128-bitstring, iv :: 96-bitstring >> ->
+        :crypto.block_decrypt(:aes_gcm, secret, iv, {sign_secret, cipher_text, cipher_tag})
+      _ ->
+        :error
+    end
+    |> case do
+      cek when bit_size(cek) in [128, 192, 256] ->
+        {:ok, cek}
+      _ ->
+        :error
+    end
+  end
+
+  # Pads a message using the PKCS #7 cryptographic message syntax.
+  #
+  # See: https://tools.ietf.org/html/rfc2315
+  # See: `pkcs7_unpad/1`
+  defp pkcs7_pad(message) do
+    bytes_remaining = rem(byte_size(message), 16)
     padding_size = 16 - bytes_remaining
-    msg <> :binary.copy(<<padding_size>>, padding_size)
+    message <> :binary.copy(<<padding_size>>, padding_size)
   end
 
-  defp unpad_message(msg) do
-    padding_size = :binary.last(msg)
+  # Unpads a message using the PKCS #7 cryptographic message syntax.
+  # 
+  # See: https://tools.ietf.org/html/rfc2315
+  # See: `pkcs7_pad/1`
+  defp pkcs7_unpad(<<>>),
+    do: :error
+  defp pkcs7_unpad(message) do
+    padding_size = :binary.last(message)
     if padding_size <= 16 do
-      msg_size = byte_size(msg)
-      if binary_part(msg, msg_size, -padding_size) == :binary.copy(<<padding_size>>, padding_size) do
-        {:ok, binary_part(msg, 0, msg_size - padding_size)}
+      message_size = byte_size(message)
+      if binary_part(message, message_size, -padding_size) === :binary.copy(<<padding_size>>, padding_size) do
+        {:ok, binary_part(message, 0, message_size - padding_size)}
       else
         :error
       end
@@ -97,10 +285,93 @@ defmodule Plug.Crypto.MessageEncryptor do
     end
   end
 
-  defp trim_secret(secret) do
-    case byte_size(secret) do
-      large when large > 32 -> :binary.part(secret, 0, 32)
-      _ -> secret
+  ## Helpers
+
+  defp encode_token(protected, encrypted_key, iv, cipher_text, cipher_tag) do
+    protected
+    |> Base.url_encode64(padding: false)
+    |> Kernel.<>(".")
+    |> Kernel.<>(Base.url_encode64(encrypted_key, padding: false))
+    |> Kernel.<>(".")
+    |> Kernel.<>(Base.url_encode64(iv, padding: false))
+    |> Kernel.<>(".")
+    |> Kernel.<>(Base.url_encode64(cipher_text, padding: false))
+    |> Kernel.<>(".")
+    |> Kernel.<>(Base.url_encode64(cipher_tag, padding: false))
+  end
+
+  defp decode_token(token) do
+    case String.split(token, ".", parts: 5) do
+      [protected, encrypted_key, iv, cipher_text, cipher_tag] ->
+        with {:ok, protected}     <- Base.url_decode64(protected, padding: false),
+             {:ok, encrypted_key} <- Base.url_decode64(encrypted_key, padding: false),
+             {:ok, iv}            <- Base.url_decode64(iv, padding: false),
+             {:ok, cipher_text}   <- Base.url_decode64(cipher_text, padding: false),
+             {:ok, cipher_tag}    <- Base.url_decode64(cipher_tag, padding: false) do
+          {true, protected, encrypted_key, iv, cipher_text, cipher_tag}
+        end
+        |> case do
+          {true, protected, encrypted_key, iv, cipher_text, cipher_tag} ->
+            {protected, encrypted_key, iv, cipher_text, cipher_tag}
+          _ ->
+            :error
+        end
+      _ ->
+        :error
     end
   end
+
+  ## Legacy Helpers
+
+  defp encode_legacy_token(sign_secret, iv, cipher_text) do
+    cipher_text = Base.encode64(cipher_text) <> "--" <> Base.encode64(iv)
+    cipher_text = Base.url_encode64(cipher_text)
+    cipher_tag = :crypto.hmac(:sha, sign_secret, cipher_text) |> Base.url_encode64
+    cipher_text <> "##" <> cipher_tag
+  end
+
+  defp decode_legacy_token(token, sign_secret) do
+    token
+    |> String.split("##", parts: 2)
+    |> case do
+      [_, _] = both -> both
+      _ -> String.split(token, "--", parts: 2)
+    end
+    |> case do
+      [cipher_text, cipher_tag]
+          when byte_size(cipher_text) > 0 and byte_size(cipher_tag) > 0 ->
+        with {:ok, cipher_tag}  <- Base.url_decode64(cipher_tag),
+             challenge           = :crypto.hmac(:sha, sign_secret, cipher_text),
+             true               <- Plug.Crypto.secure_compare(challenge, cipher_tag),
+             {:ok, cipher_text} <- Base.url_decode64(cipher_text),
+             [cipher_text, iv]  <- String.split(cipher_text, "--", parts: 2),
+             {:ok, cipher_text} <- Base.decode64(cipher_text),
+             {:ok, iv}          <- Base.decode64(iv) do
+          {true, "A256CBC-HS1", "", iv, cipher_text, cipher_tag}
+        end
+        |> case do
+          {true, protected, encrypted_key, iv, cipher_text, cipher_tag} ->
+            {protected, encrypted_key, iv, cipher_text, cipher_tag}
+          _ ->
+            :error
+        end
+      _ ->
+        :error
+    end
+  end
+
+  defp encrypt_legacy(message, cipher, secret, iv)
+      when bit_size(secret) > 256,
+    do: encrypt_legacy(message, cipher, binary_part(secret, 0, 32), iv)
+  defp encrypt_legacy(message, cipher, secret, iv) do
+    :crypto.block_encrypt(cipher, secret, iv, message)
+  end
+
+  defp decrypt_legacy(encrypted, cipher, secret, iv)
+      when bit_size(secret) > 256,
+    do: decrypt_legacy(encrypted, cipher, binary_part(secret, 0, 32), iv)
+  defp decrypt_legacy(encrypted, cipher, secret, iv) do
+    :crypto.block_decrypt(cipher, secret, iv, encrypted)
+  end
+
 end

--- a/lib/plug/crypto/message_encryptor.ex
+++ b/lib/plug/crypto/message_encryptor.ex
@@ -303,6 +303,7 @@ defmodule Plug.Crypto.MessageEncryptor do
   defp decode_token(token) do
     case String.split(token, ".", parts: 5) do
       [protected, encrypted_key, iv, cipher_text, cipher_tag] ->
+        # TODO: Use with/else once we depend on Elixir v1.3+ only
         with {:ok, protected}     <- Base.url_decode64(protected, padding: false),
              {:ok, encrypted_key} <- Base.url_decode64(encrypted_key, padding: false),
              {:ok, iv}            <- Base.url_decode64(iv, padding: false),
@@ -340,6 +341,7 @@ defmodule Plug.Crypto.MessageEncryptor do
     |> case do
       [cipher_text, cipher_tag]
           when byte_size(cipher_text) > 0 and byte_size(cipher_tag) > 0 ->
+        # TODO: Use with/else once we depend on Elixir v1.3+ only
         with {:ok, cipher_tag}  <- Base.url_decode64(cipher_tag),
              challenge           = :crypto.hmac(:sha, sign_secret, cipher_text),
              true               <- Plug.Crypto.secure_compare(challenge, cipher_tag),

--- a/lib/plug/crypto/message_verifier.ex
+++ b/lib/plug/crypto/message_verifier.ex
@@ -8,16 +8,49 @@ defmodule Plug.Crypto.MessageVerifier do
   tampered with.
   """
 
-  @delimiter "##"
+  # @delimiter "##"
+
+  @doc """
+  Signs a message according to the given secret.
+  """
+  def sign(message, secret, digest_type \\ :sha256)
+  def sign(message, secret, digest_type)
+      when is_binary(message) and is_binary(secret) and digest_type in [:sha256, :sha384, :sha512] do
+    hmac_sha2_sign(message, secret, digest_type)
+  end
+  def sign(message, secret, :sha)
+      when is_binary(message) and is_binary(secret) do
+    hmac_sha1_sign(message, secret)
+  end
 
   @doc """
   Decodes and verifies the encoded binary was not tampared with.
   """
-  def verify(binary, secret) when is_binary(binary) and is_binary(secret) do
-    case split(binary) do
-      [content, digest] when content != "" and digest != "" ->
-        if Plug.Crypto.secure_compare(digest(secret, content), digest) do
-          decode(content)
+  def verify(signed, secret)
+      when is_binary(signed) and is_binary(secret) do
+    if String.contains?(signed, ".") do
+      hmac_sha2_verify(signed, secret)
+    else
+      hmac_sha1_verify(signed, secret)
+    end
+  end
+
+  ## Signature Algorithms
+
+  defp hmac_sha1_sign(payload, key)
+      when is_binary(payload) and is_binary(key) do
+    plain_text = Base.url_encode64(payload)
+    signature  = :crypto.hmac(:sha, key, plain_text)
+    plain_text <> "##" <> Base.url_encode64(signature)
+  end
+
+  defp hmac_sha1_verify(signed, key)
+      when is_binary(signed) and is_binary(key) do
+    case decode_legacy_token(signed) do
+      {"HS1", payload, plain_text, signature} ->
+        challenge = :crypto.hmac(:sha, key, plain_text)
+        if Plug.Crypto.secure_compare(challenge, signature) do
+          {:ok, payload}
         else
           :error
         end
@@ -26,28 +59,100 @@ defmodule Plug.Crypto.MessageVerifier do
     end
   end
 
-  @doc """
-  Signs a binary according to the given secret.
-  """
-  def sign(binary, secret) when is_binary(binary) and is_binary(secret) do
-    encoded = Base.url_encode64(binary)
-    encoded <> @delimiter <> digest(secret, encoded)
+  defp hmac_sha2_to_protected(:sha256), do: "HS256"
+  defp hmac_sha2_to_protected(:sha384), do: "HS384"
+  defp hmac_sha2_to_protected(:sha512), do: "HS512"
+
+  defp hmac_sha2_to_digest_type("HS256"), do: :sha256
+  defp hmac_sha2_to_digest_type("HS384"), do: :sha384
+  defp hmac_sha2_to_digest_type("HS512"), do: :sha512
+
+  defp hmac_sha2_sign(payload, key, digest_type) do
+    protected  = hmac_sha2_to_protected(digest_type)
+    plain_text = signing_input(protected, payload)
+    signature  = :crypto.hmac(digest_type, key, plain_text)
+    encode_token(plain_text, signature)
   end
 
-  defp digest(secret, data) do
-    :crypto.hmac(:sha, secret, data) |> Base.url_encode64
+  defp hmac_sha2_verify(signed, key)
+      when is_binary(signed) and is_binary(key) do
+    case decode_token(signed) do
+      {protected, payload, plain_text, signature} when protected in ["HS256", "HS384", "HS512"] ->
+        digest_type = hmac_sha2_to_digest_type(protected)
+        challenge = :crypto.hmac(digest_type, key, plain_text)
+        if Plug.Crypto.secure_compare(challenge, signature) do
+          {:ok, payload}
+        else
+          :error
+        end
+      _ ->
+        :error
+    end
   end
 
-  # TODO: Remove after backwards compatibility period
-  defp split(binary) do
-    case String.split(binary, @delimiter) do
+  ## Helpers
+
+  defp encode_token(plain_text, signature)
+      when is_binary(plain_text) and is_binary(signature) do
+    plain_text <> "." <> Base.url_encode64(signature, padding: false)
+  end
+
+  defp decode_token(token) do
+    case String.split(token, ".", parts: 3) do
+      [protected, payload, signature] ->
+        plain_text = protected <> "." <> payload
+        with {:ok, protected} <- Base.url_decode64(protected, padding: false),
+             {:ok, payload}   <- Base.url_decode64(payload, padding: false),
+             {:ok, signature} <- Base.url_decode64(signature, padding: false) do
+          {true, protected, payload, plain_text, signature}
+        end
+        |> case do
+          {true, protected, payload, plain_text, signature} ->
+            {protected, payload, plain_text, signature}
+          _ ->
+            :error
+        end
+      _ ->
+        :error
+    end
+  end
+
+  defp signing_input(protected, payload)
+      when is_binary(protected) and is_binary(payload) do
+    protected
+    |> Base.url_encode64(padding: false)
+    |> Kernel.<>(".")
+    |> Kernel.<>(Base.url_encode64(payload, padding: false))
+  end
+
+  ## Legacy Helpers
+
+  defp decode_legacy_token(token) do
+    token
+    |> String.split("##", parts: 2)
+    |> case do
       [_, _] = both -> both
-      _ -> String.split(binary, "--")
+      _ -> String.split(token, "--", parts: 2)
+    end
+    |> case do
+      [plain_text, signature] when byte_size(plain_text) > 0 and byte_size(signature) > 0 ->
+        with {:ok, payload}   <- decode_legacy_base64(plain_text),
+             {:ok, signature} <- decode_legacy_base64(signature) do
+          {true, "HS1", payload, plain_text, signature}
+        end
+        |> case do
+          {true, protected, payload, plain_text, signature} ->
+            {protected, payload, plain_text, signature}
+          _ ->
+            :error
+        end
+      _ ->
+        :error
     end
   end
 
   # TODO: Remove after backwards compatibility period
-  defp decode(content) do
+  defp decode_legacy_base64(content) do
     case Base.url_decode64(content) do
       {:ok, binary} -> {:ok, binary}
       :error -> Base.decode64(content)

--- a/lib/plug/crypto/message_verifier.ex
+++ b/lib/plug/crypto/message_verifier.ex
@@ -101,6 +101,7 @@ defmodule Plug.Crypto.MessageVerifier do
     case String.split(token, ".", parts: 3) do
       [protected, payload, signature] ->
         plain_text = protected <> "." <> payload
+        # TODO: Use with/else once we depend on Elixir v1.3+ only
         with {:ok, protected} <- Base.url_decode64(protected, padding: false),
              {:ok, payload}   <- Base.url_decode64(payload, padding: false),
              {:ok, signature} <- Base.url_decode64(signature, padding: false) do
@@ -136,6 +137,7 @@ defmodule Plug.Crypto.MessageVerifier do
     end
     |> case do
       [plain_text, signature] when byte_size(plain_text) > 0 and byte_size(signature) > 0 ->
+        # TODO: Use with/else once we depend on Elixir v1.3+ only
         with {:ok, payload}   <- decode_legacy_base64(plain_text),
              {:ok, signature} <- decode_legacy_base64(signature) do
           {true, "HS1", payload, plain_text, signature}

--- a/lib/plug/session/cookie.ex
+++ b/lib/plug/session/cookie.ex
@@ -101,9 +101,9 @@ defmodule Plug.Session.COOKIE do
       %{encryption_salt: nil} ->
         MessageVerifier.sign(binary, derive(conn, signing_salt, key_opts))
       %{encryption_salt: key} ->
-        MessageEncryptor.encrypt_and_sign(binary,
-                                          derive(conn, key, key_opts),
-                                          derive(conn, signing_salt, key_opts))
+        MessageEncryptor.encrypt(binary,
+                                 derive(conn, key, key_opts),
+                                 derive(conn, signing_salt, key_opts))
     end
   end
 

--- a/lib/plug/session/cookie.ex
+++ b/lib/plug/session/cookie.ex
@@ -87,6 +87,7 @@ defmodule Plug.Session.COOKIE do
       %{encryption_salt: nil} ->
         MessageVerifier.verify(cookie, derive(conn, signing_salt, key_opts))
       %{encryption_salt: key} ->
+        # TODO: Change to verify/3 after backwards compatibility period.
         MessageEncryptor.verify_and_decrypt(cookie,
                                             derive(conn, key, key_opts),
                                             derive(conn, signing_salt, key_opts))

--- a/test/plug/crypto/message_encryptor_test.exs
+++ b/test/plug/crypto/message_encryptor_test.exs
@@ -7,15 +7,56 @@ defmodule Plug.Crypto.MessageEncryptorTest do
   @wrong String.duplicate("12345678", 4)
   @large String.duplicate(@right, 2)
 
+  def loop_until_fail(0, t) do
+    t
+  end
+  def loop_until_fail(n, t) do
+    encrypted = ME.encrypt_and_sign(<<0, "hełłoworld", 0>>, @right, @right, :aes_cbc256)
+    decrypted = ME.verify_and_decrypt(encrypted, @wrong, @right)
+    if decrypted === :error do
+      loop_until_fail(n, t + 1)
+    else
+      # IO.puts "encrypted = #{inspect encrypted}"
+      loop_until_fail(n - 1, t + 1)
+    end
+  end
+
   test "it encrypts/decrypts a message" do
     data = <<0, "hełłoworld", 0>>
-    encrypted = ME.encrypt_and_sign(<<0, "hełłoworld", 0>>, @right, @right)
+    encrypted = ME.encrypt(<<0, "hełłoworld", 0>>, @right, @right)
+
+    decrypted = ME.decrypt(encrypted, @wrong, @wrong)
+    assert decrypted == :error
+
+    decrypted = ME.decrypt(encrypted, @right, @wrong)
+    assert decrypted == :error
+
+    decrypted = ME.decrypt(encrypted, @wrong, @right)
+    assert decrypted == :error
+
+    decrypted = ME.decrypt(encrypted, @right, @right)
+    assert decrypted == {:ok, data}
+
+    # Legacy support for AES256-CBC with HMAC SHA-1
+    encrypted = ME.encrypt_and_sign(<<0, "hełłoworld", 0>>, @right, @right, :aes_cbc256)
+
+    decrypted = ME.verify_and_decrypt(encrypted, @wrong, @wrong)
+    assert decrypted == :error
 
     decrypted = ME.verify_and_decrypt(encrypted, @right, @wrong)
     assert decrypted == :error
 
-    decrypted = ME.verify_and_decrypt(encrypted, @wrong, @right)
-    assert decrypted == :error
+    # This can fail depending on the initialization vector
+    # decrypted = ME.verify_and_decrypt(encrypted, @wrong, @right)
+    # if decrypted !== :error do
+    #   IO.puts "encrypted = #{inspect encrypted}"
+    #   # IO.puts "wrong: #{inspect @wrong}"
+    #   # IO.puts "right: #{inspect @right}"
+    # end
+    # assert decrypted == :error
+    n = 100
+    t = loop_until_fail(n, 0)
+    IO.puts("After #{t} loops, got #{n} failures: #{(n / t) * 100}%")
 
     decrypted = ME.verify_and_decrypt(encrypted, @right, @right)
     assert decrypted == {:ok, data}
@@ -23,7 +64,36 @@ defmodule Plug.Crypto.MessageEncryptorTest do
 
   test "it uses only the first 32 bytes to encrypt/decrypt" do
     data = <<0, "helloworld", 0>>
-    encrypted = ME.encrypt_and_sign(<<0, "helloworld", 0>>, @large, @large)
+    encrypted = ME.encrypt(<<0, "helloworld", 0>>, @large, @large)
+
+    decrypted = ME.decrypt(encrypted, @large, @large)
+    assert decrypted == {:ok, data}
+
+    decrypted = ME.decrypt(encrypted, @right, @large)
+    assert decrypted == {:ok, data}
+
+    decrypted = ME.decrypt(encrypted, @large, @right)
+    assert decrypted == :error
+
+    decrypted = ME.decrypt(encrypted, @right, @right)
+    assert decrypted == :error
+
+    encrypted = ME.encrypt(<<0, "helloworld", 0>>, @right, @large)
+
+    decrypted = ME.decrypt(encrypted, @large, @large)
+    assert decrypted == {:ok, data}
+
+    decrypted = ME.decrypt(encrypted, @right, @large)
+    assert decrypted == {:ok, data}
+
+    decrypted = ME.decrypt(encrypted, @large, @right)
+    assert decrypted == :error
+
+    decrypted = ME.decrypt(encrypted, @right, @right)
+    assert decrypted == :error
+
+    # Legacy support for AES256-CBC with HMAC SHA-1
+    encrypted = ME.encrypt_and_sign(<<0, "helloworld", 0>>, @large, @large, :aes_cbc256)
 
     decrypted = ME.verify_and_decrypt(encrypted, @large, @large)
     assert decrypted == {:ok, data}
@@ -37,7 +107,7 @@ defmodule Plug.Crypto.MessageEncryptorTest do
     decrypted = ME.verify_and_decrypt(encrypted, @right, @right)
     assert decrypted == :error
 
-    encrypted = ME.encrypt_and_sign(<<0, "helloworld", 0>>, @right, @large)
+    encrypted = ME.encrypt_and_sign(<<0, "helloworld", 0>>, @right, @large, :aes_cbc256)
 
     decrypted = ME.verify_and_decrypt(encrypted, @large, @large)
     assert decrypted == {:ok, data}

--- a/test/plug/crypto/message_encryptor_test.exs
+++ b/test/plug/crypto/message_encryptor_test.exs
@@ -7,20 +7,6 @@ defmodule Plug.Crypto.MessageEncryptorTest do
   @wrong String.duplicate("12345678", 4)
   @large String.duplicate(@right, 2)
 
-  def loop_until_fail(0, t) do
-    t
-  end
-  def loop_until_fail(n, t) do
-    encrypted = ME.encrypt_and_sign(<<0, "hełłoworld", 0>>, @right, @right, :aes_cbc256)
-    decrypted = ME.verify_and_decrypt(encrypted, @wrong, @right)
-    if decrypted === :error do
-      loop_until_fail(n, t + 1)
-    else
-      # IO.puts "encrypted = #{inspect encrypted}"
-      loop_until_fail(n - 1, t + 1)
-    end
-  end
-
   test "it encrypts/decrypts a message" do
     data = <<0, "hełłoworld", 0>>
     encrypted = ME.encrypt(<<0, "hełłoworld", 0>>, @right, @right)
@@ -48,15 +34,7 @@ defmodule Plug.Crypto.MessageEncryptorTest do
 
     # This can fail depending on the initialization vector
     # decrypted = ME.verify_and_decrypt(encrypted, @wrong, @right)
-    # if decrypted !== :error do
-    #   IO.puts "encrypted = #{inspect encrypted}"
-    #   # IO.puts "wrong: #{inspect @wrong}"
-    #   # IO.puts "right: #{inspect @right}"
-    # end
     # assert decrypted == :error
-    n = 100
-    t = loop_until_fail(n, 0)
-    IO.puts("After #{t} loops, got #{n} failures: #{(n / t) * 100}%")
 
     decrypted = ME.verify_and_decrypt(encrypted, @right, @right)
     assert decrypted == {:ok, data}

--- a/test/plug/crypto/message_verifier_test.exs
+++ b/test/plug/crypto/message_verifier_test.exs
@@ -4,13 +4,33 @@ defmodule Plug.Crypto.MessageVerifierTest do
   alias Plug.Crypto.MessageVerifier, as: MV
 
   test "generates a signed message" do
-    [content, encoded] = String.split MV.sign("hello world", "secret"), "##"
+    [protected, payload, signature] = String.split MV.sign("hello world", "secret"), "."
+    assert protected |> Base.url_decode64(padding: false) == {:ok, "HS256"}
+    assert payload |> Base.url_decode64(padding: false) == {:ok, "hello world"}
+    assert byte_size(signature) == 43
+    [protected, payload, signature] = String.split MV.sign("hello world", "secret", :sha384), "."
+    assert protected |> Base.url_decode64(padding: false) == {:ok, "HS384"}
+    assert payload |> Base.url_decode64(padding: false) == {:ok, "hello world"}
+    assert byte_size(signature) == 64
+    [protected, payload, signature] = String.split MV.sign("hello world", "secret", :sha512), "."
+    assert protected |> Base.url_decode64(padding: false) == {:ok, "HS512"}
+    assert payload |> Base.url_decode64(padding: false) == {:ok, "hello world"}
+    assert byte_size(signature) == 86
+    # Legacy support for HMAC SHA-1
+    [content, encoded] = String.split MV.sign("hello world", "secret", :sha), "##"
     assert content |> Base.url_decode64 == {:ok, "hello world"}
     assert byte_size(encoded) == 28
   end
 
   test "verifies a signed message" do
-    [content, encoded] = String.split MV.sign("hello world", "secret"), "##"
+    [protected, payload, signature] = String.split MV.sign("hello world", "secret"), "."
+    assert MV.verify(protected <> "." <> payload <> "." <> signature, "secret") == {:ok, "hello world"}
+    [protected, payload, signature] = String.split MV.sign("hello world", "secret", :sha384), "."
+    assert MV.verify(protected <> "." <> payload <> "." <> signature, "secret") == {:ok, "hello world"}
+    [protected, payload, signature] = String.split MV.sign("hello world", "secret", :sha512), "."
+    assert MV.verify(protected <> "." <> payload <> "." <> signature, "secret") == {:ok, "hello world"}
+    # Legacy support for HMAC SHA-1
+    [content, encoded] = String.split MV.sign("hello world", "secret", :sha), "##"
     assert MV.verify(content <> "##" <> encoded, "secret") == {:ok, "hello world"}
     assert MV.verify(content <> "--" <> encoded, "secret") == {:ok, "hello world"}
   end
@@ -18,10 +38,36 @@ defmodule Plug.Crypto.MessageVerifierTest do
   test "does not verify a signed message if secret changed" do
     signed = MV.sign("hello world", "secret")
     assert MV.verify(signed, "secreto") == :error
+    signed = MV.sign("hello world", "secret", :sha384)
+    assert MV.verify(signed, "secreto") == :error
+    signed = MV.sign("hello world", "secret", :sha512)
+    assert MV.verify(signed, "secreto") == :error
+    # Legacy support for HMAC SHA-1
+    signed = MV.sign("hello world", "secret", :sha)
+    assert MV.verify(signed, "secreto") == :error
   end
 
   test "does not verify a tampered message" do
-    [_, encoded] = String.split MV.sign("hello world", "secret"), "##"
+    # Tampered payload
+    payload = Base.url_encode64("another world", padding: false)
+    [protected, _payload, signature] = String.split MV.sign("hello world", "secret"), "."
+    assert MV.verify(protected <> "." <> payload <> "." <> signature, "secret") == :error
+    [protected, _payload, signature] = String.split MV.sign("hello world", "secret", :sha384), "."
+    assert MV.verify(protected <> "." <> payload <> "." <> signature, "secret") == :error
+    [protected, _payload, signature] = String.split MV.sign("hello world", "secret", :sha512), "."
+    assert MV.verify(protected <> "." <> payload <> "." <> signature, "secret") == :error
+    # Tampered protected
+    [_protected, payload, signature] = String.split MV.sign("hello world", "secret"), "."
+    protected = Base.url_encode64("HS384", padding: false)
+    assert MV.verify(protected <> "." <> payload <> "." <> signature, "secret") == :error
+    [_protected, payload, signature] = String.split MV.sign("hello world", "secret", :sha384), "."
+    protected = Base.url_encode64("HS512", padding: false)
+    assert MV.verify(protected <> "." <> payload <> "." <> signature, "secret") == :error
+    [_protected, payload, signature] = String.split MV.sign("hello world", "secret", :sha512), "."
+    protected = Base.url_encode64("HS256", padding: false)
+    assert MV.verify(protected <> "." <> payload <> "." <> signature, "secret") == :error
+    # Legacy support for HMAC SHA-1
+    [_, encoded] = String.split MV.sign("hello world", "secret", :sha), "##"
     content = Base.url_encode64("another world")
     assert MV.verify(content <> "##" <> encoded, "secret") == :error
   end


### PR DESCRIPTION
First, this pull request may not be ready to merge quite yet.  I wanted to get some feedback as to whether the direction I took is an acceptable one and if so, whether there needs to be any modifications prior to merging.

I'd also like to apologize for the length of my writing here, I wanted to make sure I had done my homework before submitting these recommendations.  I have tried to summarize everything towards the beginning for those experiencing reading fatigue.

### Summary of changes

**Note:** Whenever I say "deprecate" below, I really mean "soft deprecate" or "begin the transition away from" rather than an immediate hard deprecation.

1. Deprecate AES256-CBC with HMAC SHA-1 in favor of AES128-GCM with AES256-GCM Key Wrapping in `Plug.Crypto.MessageEncryptor`.
2. Deprecate HMAC SHA-1 in favor of HMAC SHA-256 in `Plug.Crypto.MessageVerifier`.
3. Maintain backwards compatibility in `Plug.Crypto.MessageEncryptor` and `Plug.Crypto.MessageVerifier` so existing session cookies can be verified and decrypted, but new writes should use the new recommendations.
4. Provide better methods of upgrading algorithms in the future while maintaining backwards compatibility (for example, 2-3 years from now, the recommended standards might be [AES-GCM-SIV](https://tools.ietf.org/html/draft-irtf-cfrg-gcmsiv) or the winning algorithm of the [CAESAR competition](https://competitions.cr.yp.to/caesar.html) for Authenticated Encryption and [XMSS](https://tools.ietf.org/html/draft-irtf-cfrg-xmss-hash-based-signatures) for Hash-Based Signatures).
   
   This was done by using a modified form of [JWE Compact Serialization](https://tools.ietf.org/html/rfc7516#section-3.1) and [JWS Compact Serialization](https://tools.ietf.org/html/rfc7515#section-3.1) which just includes the algorithm name as the "header" in a list of Base64url without padding encoded terms.  For example `BASE64URL("HS256") || '.' || BASE64URL("message") || '.' || BASE64URL(SIGNATURE)` is the basic format of a signature token using HMAC with SHA-256.

   This should make it easy to provide backwards compatibility support for older algorithms by examining the protected header prior to performing verification or decryption.
5. Deprecate `encrypt_and_sign/3,4` in favor of `encrypt/3`.  Deprecate `verify_and_decrypt/3,4` in favor of `decrypt/3`.
   
   AES-GCM computes the authentication tag using the internal GHASH function.  It's not really the same thing as a signature.  Future encryption standards, like AES-GCM-SIV with its POLYVAL function, may compute additional tags/values which "authenticate" encrypted data before/after decryption, but behave differently from what we would normally consider a signature (verifying whether a particular message is from a specific sender).

##### Questions for discussion

1. AES-GCM mode is only supported in OTP 18+ and OpenSSL 1.0.1+.  If there is any concern for supporting OTP 17 or older versions of OpenSSL, would it be better to switch algorithms based on whether support for AES-GCM is detected?
2. I chose AES128-GCM for the actual content encryption since the key is randomly generated and encrypted with AES256-GCM Key Wrapping.  Would there be any preferences to use AES256-GCM for both operations?
3. I chose HMAC SHA-256 for the default signing algorithm.  Other supported modes are HMAC SHA-384 and HMAC SHA-512.  Users may choose these other modes by specifying the digest type.  For example, HMAC SHA-512 can be used with `Plug.Crypto.MessageVerifier.sign(message, sign_secret, :sha512)`.  Are there any preferences for something other than HMAC SHA-256 as the default?
4. Any issues or improvements to the design for future algorithm changes and backwards compatibility?

### Why are these changes necessary?

##### Short Explanation

AES256-CBC with HMAC SHA-1 uses an encryption key and signing key which are weakly linked.  This allows a valid signing key and an invalid encryption key to erroneously decrypt a message resulting in garbage data returned.  This occurs when a compatible initialization vector is randomly generated which returns a correctly padded plain text upon decryption with the wrong key, causing the tests to fail about 1 out of 120 runs.

Beyond that, AES-CBC in general is being phased out in many other communities/products/services and replaced with things like AES-CCM, AES-GCM, and CHACHA20-POLY1305.  SHA-1 is also no longer recommended for future cryptographic use.

I would like to recommend the following two changes:

1. For authenticated encryption: begin phasing out AES256-CBC with HMAC SHA-1 and replace it with AES128-GCM with AES256-GCM Key Wrapping.
2. For symmetric signatures: begin phasing out HMAC SHA-1 and replace it with HMAC SHA-256.

##### Medium Explanation

While running the tests for Plug locally, I noticed the occasional failure for the tests related to `Plug.Crypto.MessageEncryptor`.

After closer examination, I found that the failure occurs approximately 0.8% of the time (or roughly 1 out of 120 runs) based on the frequency I measured on my machine.

I wound up writing a property test with [ExCheck](https://github.com/parroty/excheck) to demonstrate the issue, but have not included it in this pull request due to compilation issues with [triq](https://github.com/krestenkrab/triq).

```elixir
property :encrypt_and_decrypt do
  bytes_gen = fn (min) ->
    size_dom = bind(non_neg_integer(), fn (size) -> max(min, size) end)
    bind(size_dom, &:crypto.strong_rand_bytes/1)
  end
  secrets_dom = such_that({large, wrong} in {bytes_gen.(64), bytes_gen.(32)}
    when binary_part(large, 0, min(byte_size(large), byte_size(wrong))) !== binary_part(wrong, 0, min(byte_size(large), byte_size(wrong))))
  generator = bind({binary(), secrets_dom},
    fn ({data, {large, wrong}}) ->
      right = binary_part(large, 0, 32)
      encrypted = ME.encrypt(data, right, right)
      large_encrypted = ME.encrypt(data, large, large)
      {encrypted, large_encrypted, data, right, wrong, large}
    end)
  for_all {encrypted, large_encrypted, data, right, wrong, large} in generator do
    :error == ME.decrypt(encrypted, right, wrong) and
    :error == ME.decrypt(encrypted, wrong, right) and
    :error == ME.decrypt(encrypted, wrong, wrong) and
    {:ok, data} == ME.decrypt(encrypted, right, right) and
    :error == ME.decrypt(encrypted, right, large) and
    {:ok, data} == ME.decrypt(encrypted, large, right) and
    :error == ME.decrypt(encrypted, large, large) and
    :error == ME.decrypt(large_encrypted, large, wrong) and
    :error == ME.decrypt(large_encrypted, wrong, large) and
    :error == ME.decrypt(large_encrypted, wrong, wrong) and
    :error == ME.decrypt(large_encrypted, large, wrong) and
    {:ok, data} == ME.decrypt(large_encrypted, large, large) and
    :error == ME.decrypt(large_encrypted, large, right) and
    {:ok, data} == ME.decrypt(large_encrypted, right, large) and
    :error == ME.decrypt(large_encrypted, right, right)
  end
end
```

(ignore this paragraph if you know how quick check works) It essentially runs the `for_all` block ~100 times with randomly generated values as specified by the `generator`.  If `false` is ever returned, it will attempt to shrink or reduce the generated values to the smallest form that still produces a failure and report on the shrunk values.

Here is an example walkthrough of the failure:

```elixir
alias Plug.Crypto.MessageEncryptor, as: ME

# The encryption key and signing key.
secret      = "abcdefghabcdefghabcdefghabcdefgh"
sign_secret = "abcdefghabcdefghabcdefghabcdefgh"

# This will generate a random 128-bit initialization vector
# internally and embed it in the output. ~0.8% of the time,
# this random IV causes the issues mentioned below.
encrypted = ME.encrypt_and_sign(<<0, "hełłoworld", 0>>, secret, sign_secret, :aes_cbc256)

# Here are 5 example outputs with an IV that fails.
# encrypted = "ekZjb3Z6MVQybnBQaFhjd2ZkU3RhUT09LS0rVHVqVEdaVjc1aXc2NlBZVTdBRE1RPT0=##vqnoVqaVEEoRqWpBPoAYVGDOhBE="
# encrypted = "OCs5ZU4rcGRpNk9JYmFmaENqK1pXZz09LS05cGNUd0RNaUlRYm1BME52VFFycU5BPT0=##fvaT36-fXf35dzkSWAXP1s_9qSA="
# encrypted = "Tms4cHk5SUhPNGJicjNHL3JxeDlHZz09LS1MZkVicXJtLzFkWEY2NVprenRmZVdBPT0=##sHFyI_rNHS088_zkWj9ip5ITETc="
# encrypted = "anNqSm5xbXFhUjRuc1R4ZW9DbVUvQT09LS1oQmxlNlg3d0c3RkF1emtHVXRwN3F3PT0=##ZBkVGHSma6Ovm7s97lByFrWVVhU="
# encrypted = "WUFKbmhsRWdCck5YL1pMdDNQOTB4UT09LS13b3dpeW1OQ2VZTVdkenpCZjN0ZkhnPT0=##BjhlwiqJE8rrxtIx81nHAOPEOoI="

# The invalid key that should cause any form of decryption to fail.
badkey = "12345678123456781234567812345678"

# This returns an error before attempting to decrypt because
# the signing key is invalid.
:error = ME.verify_and_decrypt(encrypted, secret, badkey)

# This passes the signature verification step, but should also
# return an error because the encryption key is invalid.
:error = ME.verify_and_decrypt(encrypted, badkey, sign_secret)

# However, in ~0.8% of test cases, the following is returned.
{:ok, garbage} = ME.verify_and_decrypt(encrypted, badkey, sign_secret)

# Since the signing key is valid, the HMAC SHA-1 comparison
# verifies the signature and then decrypts the cipher text
# with the invalid encryption key which produces what :crypto
# thinks is valid plain text, but is actually garbage data.
```

The same example using AES128-GCM with AES256-GCM Key Wrapping does not have the same problems:

```elixir
alias Plug.Crypto.MessageEncryptor, as: ME

# The encryption key and signing key.
secret      = "abcdefghabcdefghabcdefghabcdefgh"
sign_secret = "abcdefghabcdefghabcdefghabcdefgh"

# This will generate a random 128-bit initialization vector
# internally and embed it in the output. ~0.8% of the time,
# this random IV causes the issues mentioned below.
encrypted = ME.encrypt(<<0, "hełłoworld", 0>>, secret, sign_secret)

# Here are 5 example encryption outputs.
# encrypted = "QTEyOEdDTQ.PFBcghWDMaENoq0RPv6eoG4LkCT4lgTYGfMX-TUPB0S2InQYvM1RtvNQx1g.4rkEq56i7UtAhahx.D6298TfSD_TrVeieCEI.RnXW3GRKd_dvqyHXNzTfbg"
# encrypted = "QTEyOEdDTQ.peM8qJNbCMMkmcbLcGrms-MkEvVnqRLOF24kiaaRYkTlB9lLJNiXdiWc0Vk.1fq3yiyF_W1QYKwc.eWw0o78pnlml48I0RT8.s8QGudvjBWPgzPdzP13sPg"
# encrypted = "QTEyOEdDTQ.tz-AJON6vU9j1K5j5dC6la8diApGUPrfHMgYD7-8NYpE1X9_iUoLMlvVlLE.ZCiqqgsKLlVhyK6O.6aOaWYtC3uvdIJZSkNQ.yLyFA37-t5uOsb_AVhbVJw"
# encrypted = "QTEyOEdDTQ.NFQxH9YbtWWkPB_KczhqQKdwoE8gw7Ua0YfZCHHFamt8OnpuQXjx1YM8E7g.4UPXtKOceRq_yBHs.jut9L7lEtwKKZ4XwXIk.5zld79nBpwpK2oFTQLNxTA"
# encrypted = "QTEyOEdDTQ.fwBEx-1mcDcJ4T6LTW7H2PkG-iy97e_g9Udd_8BFbgiAbdmLOxcRWDvX7E0.di0DRHOxj-lKMfKD.xelHgwpNQRyaZ6wyr5I.J0oA9_C0kz3Gutxx2MZfFA"

# The invalid key that should cause any form of decryption to fail.
badkey = "12345678123456781234567812345678"

# This returns an error before attempting to decrypt because
# the key wrap additional authenticated data is invalid.
:error = ME.decrypt(encrypted, secret, badkey)

# This returns an error before attempting to decrypt because
# the key wrap encryption key is invalid.
:error = ME.decrypt(encrypted, badkey, sign_secret)
```

##### Long Explanation

The steps involved for AES256-CBC with HMAC SHA-1 encryption:

1. Given the following parameters:
   * Plain Text (PT or `message`)
   * 256-bit AES Content Encryption Key (CEK or `secret`)
   * ?-byte HMAC SHA-1 Authentication Key (AK or `sign_secret`)
2. Randomly generate a 128-bit AES-CBC Initialization Vector (IV).
3. Pad PT with PKCS-7 padding such that size is a multiple of 16 (PaddedPT).
4. AES256-CBC encrypt PaddedPT with CEK and IV to get Cipher Text (CT).
5. Base64 encode CT and IV and join with `"--"` (CTwithIV).
6. Base64url encode CTwithIV to get the Signing Input (SI).
7. HMAC with SHA-1 the SI and Base64url encode the result (TAG).
8. Join SI and TAG with `"##"` (ENC).

The steps involved for AES256-CBC with HMAC SHA-1 decryption:

1. Given the following parameters:
   * Encrypted Token (ENC or `encrypted`)
   * 256-bit AES Content Encryption Key (CEK or `secret`)
   * ?-byte HMAC SHA-1 Authentication Key (AK or `sign_secret`)
2. Split ENC with `"##"` to get SI and TAG.
3. HMAC with SHA-1 the SI and Base64url encode the result (CHALLENGE).
4. Securely compare CHALLENGE and TAG, if they don't match, return `:error`.
5. Base64url decode SI to get CTwithIV.
6. Split CTwithIV with `"--"` and Base64 decode to get CT and IV.
5. AES256-CBC decrypt CT with CEK and IV to get PaddedPT.
6. Unpad PaddedPT with PKCS-7 padding to get PT.

Here is a reduced example of AES256-CBC with HMAC SHA-1 minus the PKCS-7 padding part to better demonstrate the problem.

```elixir
# Reduced Example of AES256-CBC with HMAC SHA-1 problem

## Variables
# Mapping of encrypt_and_sign parameters to variables
#   message     = plain_text
#   secret      = cek
#   sign_secret = ak
plain_text = "abcdefghijklmnop" # 16-byte Plain Text
cek        = << 0 :: 256 >>     # 256-bit AES Content Encryption Key
ak         = << 1 :: 256 >>     # 256-bit HMAC SHA-1 Authentication Key
iv         = << 2 :: 128 >>     # 128-bit AES-CBC Initialization Vector

## Encrypt
cipher_text = :crypto.block_encrypt(:aes_cbc256, cek, iv, plain_text)
cipher_tag  = :crypto.hmac(:sha, ak, iv <> cipher_text)

# cipher_text = <<194,240,87,8,253,143,118,144,93,51,164,208,139,231,194,186>>
# cipher_tag  = <<82,118,235,137,55,139,240,93,113,97,203,181,0,52,112,91,86,253,9,154>>

## Decrypt
challenge = :crypto.hmac(:sha, ak, iv <> cipher_text)
decrypted =
  if challenge === cipher_tag do
    :crypto.block_decrypt(:aes_cbc256, cek, iv, cipher_text)
  else
    :error
  end
decrypted !== :error     # => true
decrypted === plain_text # => true
decrypted                # => "abcdefghijklmnop"

## Invalid Variables
# Mapping of verify_and_decrypt parameters to variables
#   secret      = bad_kw_cek
#   sign_secret = bad_kw_aad
bad_cek = << 3 :: 256 >>
bad_ak  = << 4 :: 256 >>

## Decrypt with invalid secret and invalid sign_secret (should return :error)
challenge = :crypto.hmac(:sha, bad_ak, iv <> cipher_text)
decrypted =
  if challenge === cipher_tag do
    :crypto.block_decrypt(:aes_cbc256, bad_cek, iv, cipher_text)
  else
    :error
  end
decrypted !== :error     # => false

## Decrypt with valid secret and invalid sign_secret (should return :error)
challenge = :crypto.hmac(:sha, bad_ak, iv <> cipher_text)
decrypted =
  if challenge === cipher_tag do
    :crypto.block_decrypt(:aes_cbc256, cek, iv, cipher_text)
  else
    :error
  end
decrypted !== :error     # => false

## Decrypt with invalid secret and valid sign_secret (should return :error)
challenge = :crypto.hmac(:sha, ak, iv <> cipher_text)
decrypted =
  if challenge === cipher_tag do
    :crypto.block_decrypt(:aes_cbc256, bad_cek, iv, cipher_text)
  else
    :error
  end
decrypted !== :error     # => true
decrypted === plain_text # => false
decrypted                # => <<192,161,187,41,100,123,31,150,232,114,113,156,3,219,119,120>>
```

The steps involved for AES128-GCM with AES256-GCM Key Wrapping encryption:

1. Given the following parameters:
   * Plain Text (PT or `message`)
   * 256-bit AES Content Encryption Key for Key Wrap (KWCEK or `secret`)
   * ?-byte AEAD Additional Authenticated Data for Key Wrap (KWAAD or `sign_secret`)
2. Randomly generate a 128-bit AES-GCM Content Encryption Key (CEK).
3. Randomly generate a 96-bit AES-GCM Initialization Vector (IV).
4. AES128-GCM encrypt PT with CEK, IV, and `"A128GCM"` as AAD to get Cipher Text (CT) and Cipher Tag (TAG).
5. Randomly generate a 96-bit AES-GCM Initialization Vector for Key Wrap (KWIV).
6. AES256-GCM encrypt CEK with KWCEK, KWIV, and KWAAD to get the Key Wrap Cipher Text (KWCT) and Key Wrap Cipher Tag (KWTAG).
7. Join KWCT, KWTAG, and KWIV to form the Encrypted Key (ENCKEY).
8. Base64url encode without padding AAD, ENCKEY, IV, CT, and TAG and join with `"."` (ENC).

The steps involved for AES128-GCM with AES256-GCM Key Wrapping decryption:

1. Given the following parameters:
   * Encrypted Token (ENC or `encrypted`)
   * 256-bit AES Content Encryption Key for Key Wrap (KWCEK or `secret`)
   * ?-byte AEAD Additional Authenticated Data for Key Wrap (KWAAD or `sign_secret`)
2. Split ENV with `"."` and Base64url decode without padding to get AAD, ENCKEY, IV, CT, and TAG.
3. Split ENCKEY by 256, 128, and 96 bits to get KWCT, KWTAG, and KWIV.
4. AES256-GCM decrypt KWCT and KWTAG with KWCEK, KWIV, and KWAAD to get the AES-GCM Content Encryption Key (CEK), if decryption fails return `:error`.
5. AES128-GCM decrypt CT and TAG with CEK, IV, and AAD to get PT.

Here is a reduced example of AES128-GCM with AES256-GCM Key Wrapping.

```elixir
# Reduced Example of AES128-GCM with AES256-GCM Key Wrap

## Variables
# Mapping of encrypt_and_sign parameters to variables
#   message     = plain_text
#   secret      = kw_cek
#   sign_secret = kw_aad
plain_text = "abcdefghijklmnop" # 16-byte Plain Text
kw_cek     = << 0 :: 256 >>     # 256-bit AES Content Encryption Key for Key Wrap
kw_aad     = << 1 :: 256 >>     # AEAD Additional Authenticated Data for Key Wrap
kw_iv      = << 2 :: 96 >>      # 96-bit AES-GCM Initialization Vector for Key Wrap
cek        = << 3 :: 128 >>     # 128-bit randomly generated AES Content Encryption Key
aad        = <<>>               # AEAD Additional Authenticated Data
iv         = << 4 :: 96 >>      # 96-bit AES-GCM Initialization Vector

## Encrypt
{   cipher_text,    cipher_tag} = :crypto.block_encrypt(:aes_gcm, cek, iv, {aad, plain_text})
{kw_cipher_text, kw_cipher_tag} = :crypto.block_encrypt(:aes_gcm, kw_cek, kw_iv, {kw_aad, cek})

# cipher_text    = <<245,85,117,170,125,8,201,100,98,248,175,247,59,46,13,82>>
# cipher_tag     = <<38,82,66,195,32,104,237,43,83,159,129,35,147,210,127,111>>
# kw_cipher_text = <<190,44,54,51,249,251,181,74,97,136,146,214,135,87,185,96>>
# kw_cipher_tag  = <<239,96,255,0,14,148,163,150,121,52,49,245,171,61,134,3>>

## Decrypt
unwrapped_cek = :crypto.block_decrypt(:aes_gcm, kw_cek, kw_iv, {kw_aad, kw_cipher_text, kw_cipher_tag})
unwrapped_cek !== :error # => true
unwrapped_cek === cek    # => true
unwrapped_cek            # => <<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3>>
decrypted = :crypto.block_decrypt(:aes_gcm, unwrapped_cek, iv, {aad, cipher_text, cipher_tag})
decrypted !== :error     # => true
decrypted === plain_text # => true
decrypted                # => "abcdefghijklmnop"

## Invalid Variables
# Mapping of verify_and_decrypt parameters to variables
#   secret      = bad_kw_cek
#   sign_secret = bad_kw_aad
bad_kw_cek = << 5 :: 256 >>
bad_kw_aad = << 6 :: 256 >>

## Decrypt with invalid secret and invalid sign_secret (should return :error)
unwrapped_cek = :crypto.block_decrypt(:aes_gcm, bad_kw_cek, kw_iv, {bad_kw_aad, kw_cipher_text, kw_cipher_tag})
unwrapped_cek !== :error # => false

## Decrypt with valid secret and invalid sign_secret (should return :error)
unwrapped_cek = :crypto.block_decrypt(:aes_gcm, kw_cek, kw_iv, {bad_kw_aad, kw_cipher_text, kw_cipher_tag})
unwrapped_cek !== :error # => false

## Decrypt with invalid secret and valid sign_secret (should return :error)
unwrapped_cek = :crypto.block_decrypt(:aes_gcm, bad_kw_cek, kw_iv, {kw_aad, kw_cipher_text, kw_cipher_tag})
unwrapped_cek !== :error # => false
```

### References

* [Cisco: Next Generation Encryption](http://www.cisco.com/c/en/us/about/security-center/next-generation-cryptography.html)

  > [AES-GCM and HMAC-SHA-256] are expected to meet the security and scalability requirements of the next two decades
  > 
  > [SHA-1] is recommended that these legacy algorithms be phased out and replaced with stronger algorithms
* [CloudFlare: Padding oracles and the decline of CBC-mode cipher suites](https://blog.cloudflare.com/padding-oracles-and-the-decline-of-cbc-mode-ciphersuites/)

  This deals more with the TLS standard of MAC-then-encrypt versus Plug's encrypt-then-MAC behavior, but it's an interesting read.

  > Most modern browsers and operating systems have adopted at least one AEAD cipher suite in their TLS software. The most popular is AES-GCM...
  > 
  > It’s our responsibility to keep our customers secure by implementing the latest standards, like AEAD cipher suites.
* [Cryptosense: Choice of Algorithms in the W3C Crypto API](https://cryptosense.com/choice-of-algorithms-in-the-w3c-crypto-api/)
  
  > AES-CBC mode is not CCA secure. It is secure against chosen plaintext attacks (CPA-secure) if the IV is random, but not if the IV is a nonce.
  > 
  > It does not tolerate a padding oracle – indeed, in practice, padding oracle attacks are common and the padding mode suggested in the current draft is exactly that which gives rise to most of these attacks.
  > 
  > &ldquo;I am unable to think of any cryptographic design problem where, absent major legacy considerations, any of CBC, CFB, or OFB would represent the mode of choice.&rdquo; &mdash; Phillip Rogaway
  > 
  > [AES-GCM] mode has a security proof – the security notion is AEAD (Authenticated Encryption with Associated Data), which (loosely speaking) means that the encryption part is CCA-secure and the message and associated data are unforgeable. 
  > 
  > A procedure is known to obtain SHA-1 collisions in less than 2<sup>62</sup> operations.
* [chromium: Disable AES-256-CBC modes by default](https://bugs.chromium.org/p/chromium/issues/detail?id=442572)
  
  The chromium team wound up deciding to keep AES-CBC around for a little longer, but the final comment on the issue illustrates that it will be eventually removed.

  > I would love to lose CBC mode ciphers, AES-258 and AES-128, but that's probably a ways out.
* [StackExchange: Practical disadvantages of GCM mode encryption](http://crypto.stackexchange.com/a/10808)
  
  The question is actually about the downsides of AES-GCM, but the accepted answer has a few points as to why GCM is preferable over CBC.
  
  > CBC mode requires padding input to the block size, thus GCM mode produces smaller output if input is not multiple of block size.
  > 
  > GCM is very good mode of operation, and it often is more convenient than legacy algorithms combinations like CBC + HMAC.
* [COSE: CBOR Object Signing and Encryption](https://tools.ietf.org/html/draft-ietf-cose-msg)
  
  > When using AES-GCM, the following restrictions MUST be enforced:
  > 
  > * The key and nonce pair MUST be unique for every message encrypted.
* [JWA: Key Encryption with AES GCM](https://tools.ietf.org/html/rfc7518#section-4.7) (defines A128GCMKW, A192GCMKW, and A256GCMKW standards)
