### PR TITLE
Add title attribute to header message paragraph

### DIFF
--- a/lib/plug/templates/debugger.eex
+++ b/lib/plug/templates/debugger.eex
@@ -593,7 +593,7 @@
     <div class="top">
         <header class="exception">
             <h2><strong><%= h(@title) %></strong> <span>at <%= h(method(@conn)) %> <%= h(@conn.request_path) %></span></h2>
-            <p><%= h(@message) %></p>
+            <p title="<%= h(@message) %>"><%= h(@message) %></p>
         </header>
     </div>
 


### PR DESCRIPTION
This adds a `title` attribute to the `<p>` tag in the debugger template header. This allows one to mouse over the error message and see the entire unclipped message

[http://imgur.com/gallery/vvJtT3W/](http://imgur.com/gallery/vvJtT3W/)

Previously, there was no way to see the entire error message