### PR TITLE
Change typespec of media_type params to map

### DIFF
--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -3,7 +3,7 @@ defmodule Plug.Conn.Utils do
   Utilities for working with connection data
   """
 
-  @type params :: [{binary, binary}]
+  @type params :: %{binary => binary}
 
   @upper ?A..?Z
   @lower ?a..?z


### PR DESCRIPTION
I noticed dialyzer warnings in my own code when calling `Plug.Conn.Utils.content_type`. It seems the value of `params` in the return will only ever be a Map and not `[{binary, binary}]`.

If I change the `@type` to `map()` this error goes away:

```
The call 'Elixir.Map':get(params@1::[{binary(),binary()}],<<_:56>>) will never
return since the success typing is (map(),any()) -> any() and the contract is
(map(),key()) -> value()
```