### PR TITLE
Raise when encoding lists with maps with 0 or more than 1 elems

### DIFF
--- a/lib/plug/conn/query.ex
+++ b/lib/plug/conn/query.ex
@@ -186,8 +186,13 @@ defmodule Plug.Conn.Query do
 
   # covers non-keyword lists
   defp encode_pair(parent_field, list, encoder) when is_list(list) do
-    prune Enum.flat_map list, fn value ->
-      [?&, encode_pair(parent_field <> "[]", value, encoder)]
+    prune Enum.flat_map list, fn
+      value when is_map(value) and map_size(value) != 1 ->
+        raise ArgumentError,
+          "cannot encode maps inside lists when the map has 0 or more than 1 elements, " <>
+          "got: #{inspect(value)}"
+      value ->
+        [?&, encode_pair(parent_field <> "[]", value, encoder)]
     end
   end
 

--- a/test/plug/conn/query_test.exs
+++ b/test/plug/conn/query_test.exs
@@ -133,6 +133,18 @@ defmodule Plug.Conn.QueryTest do
     assert encode(%{filter: [], foo: "bar", baz: "bat"}) == "baz=bat&foo=bar"
   end
 
+  test "encode raises when there's a map with 0 or >1 elems in a list" do
+    message = ~r/cannot encode maps inside lists/
+
+    assert_raise ArgumentError, message, fn ->
+      encode(%{foo: [%{a: 1, b: 2}]})
+    end
+
+    assert_raise ArgumentError, message, fn ->
+      encode(%{foo: [%{valid: :map}, %{}]})
+    end
+  end
+
   test "raise plug exception on bad www-form" do
     assert_raise Plug.Conn.InvalidQueryError, fn ->
       decode("_utf8=%R2%9P%93")


### PR DESCRIPTION
Should fix #428.