### PR TITLE
Specify that :host is optional for Plug.SSL

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -35,7 +35,8 @@ defmodule Plug.SSL do
     * `:expires` - seconds to expires for HSTS, defaults to 31536000 (a year).
     * `:subdomains` - a boolean on including subdomains or not in HSTS,
       defaults to false.
-    * `:host` - a new host to redirect to if the request's scheme is `http`.
+    * `:host` - a new host to redirect to if the request's scheme is `http`,
+      defaults to `conn.host`.
 
   ## Port
 


### PR DESCRIPTION
Add comment to docs explaining that `conn.host` will be used if no host is provided.
Resolve #439