### PR TITLE
Remove error in Plug.Builder eagerness

### DIFF
--- a/lib/plug/builder.ex
+++ b/lib/plug/builder.ex
@@ -128,10 +128,6 @@ defmodule Plug.Builder do
     plugs        = Module.get_attribute(env.module, :plugs)
     builder_opts = Module.get_attribute(env.module, :plug_builder_opts)
 
-    if plugs == [] do
-      raise "no plugs have been defined in #{inspect env.module}"
-    end
-
     {conn, body} = Plug.Builder.compile(env, plugs, builder_opts)
 
     quote do

--- a/test/plug/builder_test.exs
+++ b/test/plug/builder_test.exs
@@ -118,13 +118,6 @@ defmodule Plug.BuilderTest do
     end
   end
 
-  test "an exception is raised at compile time if a Plug.Builder plug " <>
-      "doesn't call plug/2" do
-    assert_raise RuntimeError, fn ->
-      defmodule BadPlug, do: use Plug.Builder
-    end
-  end
-
   test "an exception is raised at compile time if a plug with no call/2 " <>
       "function is plugged" do
     assert_raise ArgumentError, fn ->


### PR DESCRIPTION
## Today

Currently a Plug.Builder raises an error during compilation when nothing has been plugged. It makes sense from the standpoint of the module not performing anything when no plugs have been added to the pipeline (an effectively "useless" pipeline), but preventing compilation of such a program may be too opinionated of Plug.Builder.

## Options

There seem to be a few options:
- leave it alone, fail hard
- make it configurable (e.g. `use Plug.Builder, strict: true`)
- remove the error

Obviously, the first option is up to your (the project owners). Option 2, while the most flexible, also adds some complexity for a feature that may or may not be particularly valuable. The last option seems to be the "easiest", but alas depends on the project's view of the feature.

## Picking Option 3

One must assume that this is done to raise awareness of an unused Plug.Builder, but perhaps that should also be apparent to the programmer given a lack of calls to plug/1/2. Further, there is no way to protect against plugging a "dummy" function to make the error go away and still have a "useless" Plug.Builder module.

This came up in particular while trying to use Plug.Builder in Phoenix.Endpoint in place of the manual implementation that currently exists. However, endpoints do not ship with any plugs, so compilation fails for the simplest endpoint uses (e.g. the phoenix test suite).

See the proposed Phoenix.Endpoint change https://github.com/iamvery/phoenix/commit/045963d6fc96f92351950852b1d775922c07d872 and notice a "dummy" function must be plugged to keep Plug.Builder happy. Beyond feeling like a hack, perhaps there is an ever-so-slight performance hit for the extra function call?

## Summary

What do you think about such a change? On one hand, I understand the desire to fail fast/early, but does it really prevent someone from doing something they didn't intend?

Thanks for taking the time to look at this! ❤️ 