### PR TITLE
Extend router macros to accept a plug and options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.3.0-dev
 
 * Enhancements
+  * Make path parameters available in `conn.params`
   * Add `:init_opts` option to forward macro for plug options
 
 ## v1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+## v1.3.0-dev
+
+* Enhancements
+  * Add `:init_opts` option to forward macro for plug options
+
 ## v1.2.2
 
 * Bug fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.3.0-dev
 
 * Enhancements
+  * Extend match macros to accept a plug and options
   * Make path parameters available in `conn.params`
   * Add `:init_opts` option to forward macro for plug options
 

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -282,11 +282,13 @@ defmodule Plug.Router do
   `forward` accepts the following options:
 
     * `:to` - a Plug the requests will be forwarded to.
+    * `:init_opts` - the options for the target Plug.
     * `:host` - a string representing the host or subdomain, exactly like in
       `match/3`.
     * `:private` - values for `conn.private`, exactly like in `match/3`.
 
-  All remaining options are passed to the target plug.
+  If `:init_opts` is undefined, then all remaining options are passed
+  to the target plug.
 
   ## Examples
 
@@ -300,11 +302,14 @@ defmodule Plug.Router do
 
       forward "/foo/bar", to: :foo_bar_plug, host: "foobar."
       forward "/api", to: ApiRouter, plug_specific_option: true
+      forward "/baz", to: BazPlug, init_opts: [plug_specific_option: true]
   """
   defmacro forward(path, options) when is_binary(path) do
     quote bind_quoted: [path: path, options: options] do
+      # TODO: Require use of `:init_opts` for passing Plug options in 2.0
       {target, options}       = Keyword.pop(options, :to)
       {options, plug_options} = Keyword.split(options, [:host, :private])
+      plug_options = Keyword.get(plug_options, :init_opts, plug_options)
 
       if is_nil(target) or !is_atom(target) do
         raise ArgumentError, message: "expected :to to be an alias or an atom"

--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -67,6 +67,23 @@ defmodule Plug.Router.Utils do
   end
 
   @doc """
+  Builds a list of path param names and var match pairs that can bind
+  to dynamic path segment values. Excludes params with underscores;
+  otherwise, the compiler will warn about used underscored variables
+  when they are unquoted in the macro.
+
+  ## Examples
+
+      iex> Plug.Router.Utils.build_path_params_match([:id])
+      [{"id", {:id, [], nil}}]
+  """
+  def build_path_params_match(vars) do
+    vars
+    |> Enum.map(&{Atom.to_string(&1), Macro.var(&1, nil)})
+    |> Enum.reject(&match?({"_" <> _var, _macro}, &1))
+  end
+
+  @doc """
   Forwards requests to another Plug at a new path.
   """
   def forward(%Plug.Conn{path_info: path, script_name: script} = conn, new_path, target, opts) do

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -126,6 +126,9 @@ defmodule Plug.RouterTest do
       conn |> resp(200, bat)
     end
 
+    get "/plug/match", to: SamplePlug
+    get "/plug/match/options", to: SamplePlug, init_opts: :foo
+
     forward "/step1", to: Reforward
     forward "/forward", to: Forward
     forward "/nested/forward", to: Forward
@@ -227,6 +230,16 @@ defmodule Plug.RouterTest do
   test "dispatch wrong verb" do
     conn = call(Sample, conn(:post, "/1/bar"))
     assert conn.resp_body == "oops"
+  end
+
+  test "dispatch to plug" do
+    conn = call(Sample, conn(:get, "/plug/match"))
+    assert conn.resp_body == "ok"
+  end
+
+  test "dispatch to plug with options" do
+    conn = call(Sample, conn(:get, "/plug/match/options"))
+    assert conn.resp_body == ":foo"
   end
 
   test "dispatch with forwarding" do

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -134,6 +134,7 @@ defmodule Plug.RouterTest do
 
     forward "plug/forward", to: SamplePlug
     forward "plug/options", to: SamplePlug, foo: :bar, private: %{baz: :qux}
+    forward "plug/init_opts", to: SamplePlug, init_opts: [foo: :bar], private: %{baz: :qux}
 
     match _ do
       conn |> resp(404, "oops")
@@ -355,6 +356,12 @@ defmodule Plug.RouterTest do
 
   test "forwards to a plug with options" do
     conn = call(Sample, conn(:get, "/plug/options"))
+    assert conn.private[:baz] == :qux
+    assert conn.resp_body == "[foo: :bar]"
+  end
+
+  test "forwards to a plug with plug options" do
+    conn = call(Sample, conn(:get, "/plug/init_opts"))
     assert conn.private[:baz] == :qux
     assert conn.resp_body == "[foo: :bar]"
   end


### PR DESCRIPTION
Feature branch to allow `match` macros to accept a plug, and the `forward` macro to accept explicit `:init_opts` option, and parse dynamic path segments as `conn.params`.

Addresses issue #458

- [x] Test `forward` macro forwarding to a plug that accepts options 
- [x] Add `:init_opts` option to `forward` macro
- [x] Add TODO to remove original `forward` macro options behavior for 2.0
- [x] Extend `match` macros to accept a plug and options
- [x] Make dynamic path segment key/values available in `conn.params`
- [x] Get PR #461 accepted and rebase on top of it
- [x] Make sure documentation, examples, tests are complete