### PR TITLE
Add conn.path_params, populated by the Router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Extend match macros to accept a plug and options
   * Make path parameters available in `conn.params`
   * Add `:init_opts` option to forward macro for plug options
+  * Add the `:path_params` field to `Plug.Conn` to access path params
+    apart from the `params` field
 
 * Bug fixes
   * Keep `body_params` unfetched if the content-type is allowed to

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -43,7 +43,9 @@ defmodule Plug.Conn do
     * `cookies`- the request cookies with the response cookies
     * `body_params` - the request body params, populated through a `Plug.Parsers` parser.
     * `query_params` - the request query params, populated through `fetch_query_params/2`
+    * `path_params` - the request path params, populated by a `Plug.Router`
     * `params` - the request params, the result of merging the `:body_params` and `:query_params`
+       with `:path_params`
     * `req_cookies` - the request cookies (without the response ones)
 
   ## Response fields
@@ -137,6 +139,7 @@ defmodule Plug.Conn do
               owner:           owner,
               params:          params | Unfetched.t,
               path_info:       segments,
+              path_params:     params | Unfetched.t,
               port:            :inet.port_number,
               private:         assigns,
               query_params:    params | Unfetched.t,
@@ -165,6 +168,7 @@ defmodule Plug.Conn do
             method:          "GET",
             owner:           nil,
             params:          %Unfetched{aspect: :params},
+            path_params:     %Unfetched{aspect: :path_params},
             path_info:       [],
             port:            0,
             private:         %{},

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -61,7 +61,7 @@ defmodule Plug.Router do
       end
 
   The `:name` parameter will also be available in the function body as
-  `conn.params["name"]`.
+  `conn.params["name"]` and `conn.path_params["name"]`.
 
   Routes allow for globbing which will match the remaining parts
   of a route and can be available as a parameter in the function
@@ -288,7 +288,7 @@ defmodule Plug.Router do
   Forwards requests to another Plug. The `path_info` of the forwarded
   connection will exclude the portion of the path specified in the
   call to `forward`. If the path contains any parameters, those will
-  be available in the target Plug in `conn.params`.
+  be available in the target Plug in `conn.params` and `conn.path_params`.
 
   ## Options
 
@@ -402,10 +402,13 @@ defmodule Plug.Router do
       defp do_match(unquote(conn), unquote(method), unquote(match), unquote(host)) when unquote(guards) do
         unquote(private)
 
-        conn = update_in unquote(conn).params, fn
+        merge_params = fn
           %Plug.Conn.Unfetched{} -> unquote({:%{}, [], params})
           fetched -> Map.merge(fetched, unquote({:%{}, [], params}))
         end
+        conn = update_in unquote(conn).params, merge_params
+        conn = update_in conn.path_params, merge_params
+
         Plug.Conn.put_private(conn, :plug_route, fn var!(conn) -> unquote(body) end)
       end
     end

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -31,6 +31,15 @@ defmodule Plug.ParsersTest do
     assert conn.params["params"] == "baz"
   end
 
+  test "parsing prefers path params over body params" do
+    conn = %{conn(:post, "/", "foo=body") | params: %{"foo" => "bar"},
+             path_params: %{"foo" => "path"}}
+    conn = conn
+           |> put_req_header("content-type", "application/x-www-form-urlencoded")
+           |> parse()
+    assert conn.params["foo"] == "path"
+  end
+
   test "parsing prefers body params over query params with existing params" do
     conn = %{conn(:post, "/?foo=query", "foo=body") | params: %{"foo" => "params"}}
     conn = conn


### PR DESCRIPTION
Feature branch to add `path_params` to `%Plug.Conn{}` and have them assigned by the Router.

`path_params` should take priority over `body_params` and `query_params`, no matter the order they are fetched in.

Looking for critique on:

* Is the documentation clear?
* Is the test coverage sufficient?
* The params logic is now shared between Parsers and Router. Should this be refactored?

cc @josevalim @Msch