### PR TITLE
Keep body_params unfetched on parsing pass through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   * Make path parameters available in `conn.params`
   * Add `:init_opts` option to forward macro for plug options
 
+* Bug fixes
+  * Keep `body_params` unfetched if the content-type is allowed to
+    pass through the parser.
+
 ## v1.2.2
 
 * Bug fix

--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -231,7 +231,7 @@ defmodule Plug.Parsers do
   defp ensure_accepted_mimes(conn, _type, _subtype, ["*/*"]), do: conn
   defp ensure_accepted_mimes(conn, type, subtype, pass) do
     if "#{type}/#{subtype}" in pass || "#{type}/*" in pass do
-      %{conn | body_params: %{}}
+      conn
     else
       raise UnsupportedMediaTypeError, media_type: "#{type}/#{subtype}"
     end

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -124,14 +124,14 @@ defmodule Plug.ParsersTest do
       |> put_req_header("content-type", "text/plain")
       |> parse(pass: ["text/plain", "application/json"])
     assert conn.params["foo"] == "bar"
-    assert conn.body_params == %{}
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
 
     conn =
       conn(:post, "/?foo=bar", "foo=baz")
       |> put_req_header("content-type", "application/json")
       |> parse(pass: ["text/plain", "application/json"])
     assert conn.params["foo"] == "bar"
-    assert conn.body_params == %{}
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
   end
 
   test "does not raise when request cannot be processed if accepts mime range" do
@@ -140,6 +140,6 @@ defmodule Plug.ParsersTest do
       |> put_req_header("content-type", "text/plain")
       |> parse(pass: ["text/plain", "text/*"])
     assert conn.params["foo"] == "bar"
-    assert conn.body_params == %{}
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
   end
 end

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -115,6 +115,7 @@ defmodule Plug.ParsersTest do
       |> put_req_header("content-type", "text/plain")
       |> parse(pass: ["*/*"])
     assert conn.params["foo"] == "bar"
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
   end
 
   test "does not raise when request cannot be processed if mime accepted" do
@@ -123,12 +124,14 @@ defmodule Plug.ParsersTest do
       |> put_req_header("content-type", "text/plain")
       |> parse(pass: ["text/plain", "application/json"])
     assert conn.params["foo"] == "bar"
+    assert conn.body_params == %{}
 
     conn =
       conn(:post, "/?foo=bar", "foo=baz")
       |> put_req_header("content-type", "application/json")
       |> parse(pass: ["text/plain", "application/json"])
     assert conn.params["foo"] == "bar"
+    assert conn.body_params == %{}
   end
 
   test "does not raise when request cannot be processed if accepts mime range" do
@@ -137,5 +140,6 @@ defmodule Plug.ParsersTest do
       |> put_req_header("content-type", "text/plain")
       |> parse(pass: ["text/plain", "text/*"])
     assert conn.params["foo"] == "bar"
+    assert conn.body_params == %{}
   end
 end


### PR DESCRIPTION
This fixes an apparent bug in `Plug.Parsers` where a `"*/*"` pass through would leave `body_params` unfetched, but a specific content-type pass through would change it to `%{}`.

The test suite has no coverage of this behavior either way. However, I believe the correct decision is to keep `body_params` unfetched if the Parsers allow it to pass through. This is desirable if another plug or forwarded-to router later in the pipeline has a parser set up for this content-type.

This PR fixes the bug and adds four assertions to the test suite to mitigate regressions.

This issue came up while reviewing #466 and should be merged first, so that PR can assume the correct behavior applies. See specifically [this comment](https://github.com/elixir-lang/plug/pull/466#issuecomment-254866529) from @josevalim.