### PR TITLE
Add Plug.Test.init_test_session/2 for initializing a session

### DIFF
--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -55,7 +55,10 @@ defmodule Plug.Session do
   end
 
   def call(conn, config) do
-    Conn.put_private(conn, :plug_session_fetch, fetch_session(config))
+    conn
+    |> Conn.put_private(:plug_session_init, conn.private[:plug_session] || %{})
+    |> Conn.put_private(:plug_session, nil)
+    |> Conn.put_private(:plug_session_fetch, fetch_session(config))
   end
 
   defp convert_store(store) do
@@ -75,6 +78,8 @@ defmodule Plug.Session do
         else
           {nil, %{}}
         end
+
+      session = Map.merge(session, conn.private.plug_session_init)
 
       conn
       |> Conn.put_private(:plug_session, session)

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -123,4 +123,26 @@ defmodule Plug.Test do
       {key, value}, acc -> put_req_cookie(acc, to_string(key), value)
     end
   end
+
+  @doc """
+  Initializes the session with the given contents.
+
+  If the session has already been initialized, the new contents will be merged
+  with the previous ones.
+  """
+  @spec init_test_session(Conn.t, %{(String.t | atom) => any}) :: Conn.t
+  def init_test_session(conn, session) do
+    conn =
+      if conn.private[:plug_session_fetch] do
+        Conn.fetch_session(conn)
+      else
+        conn
+        |> Conn.put_private(:plug_session, %{})
+        |> Conn.put_private(:plug_session_fetch, :done)
+      end
+
+    Enum.reduce(session, conn, fn {key, value}, conn ->
+      Conn.put_session(conn, key, value)
+    end)
+  end
 end


### PR DESCRIPTION
This is my try at solving #455.

If `Plug.Session` has been called on the `conn`, this implementation will fetch the session before merging the given values, otherwise it will mark the session as fetched after having replaced it with the new one.

Currently, if `Plug.Session` is called *after* `init_test_session/2`, it will completely replace the session, is that the desired behavior?