### PR TITLE
Allow custom types based on the config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,8 @@
+use Mix.Config
+
+if Mix.env == :test do
+  config :plug, :statuses, %{
+    418 => "Totally not a teapot",
+    451 => "Unavailable For Legal Reasons"
+  }
+end

--- a/lib/plug/adapters/cowboy/conn.ex
+++ b/lib/plug/adapters/cowboy/conn.ex
@@ -2,6 +2,8 @@ defmodule Plug.Adapters.Cowboy.Conn do
   @behaviour Plug.Conn.Adapter
   @moduledoc false
 
+  @statuses Application.get_env(:plug, :statuses, %{})
+
   alias :cowboy_req, as: Request
 
   def conn(req, transport) do
@@ -31,9 +33,8 @@ defmodule Plug.Adapters.Cowboy.Conn do
   end
 
   def send_resp(req, status, headers, body) do
-    statuses = Application.get_env(:plug, :statuses, %{})
     status =
-      case Map.get(statuses, status) do
+      case Map.get(@statuses, status) do
         nil -> status
         reason_phrase -> "#{status} #{reason_phrase}"
       end

--- a/lib/plug/adapters/cowboy/conn.ex
+++ b/lib/plug/adapters/cowboy/conn.ex
@@ -2,8 +2,6 @@ defmodule Plug.Adapters.Cowboy.Conn do
   @behaviour Plug.Conn.Adapter
   @moduledoc false
 
-  @statuses Application.get_env(:plug, :statuses, %{})
-
   alias :cowboy_req, as: Request
 
   def conn(req, transport) do
@@ -33,12 +31,7 @@ defmodule Plug.Adapters.Cowboy.Conn do
   end
 
   def send_resp(req, status, headers, body) do
-    status =
-      case Map.get(@statuses, status) do
-        nil -> status
-        reason_phrase -> "#{status} #{reason_phrase}"
-      end
-
+    status = "#{status} #{Plug.Conn.Status.string(status)}"
     {:ok, req} = Request.reply(status, headers, body, req)
     {:ok, nil, req}
   end

--- a/lib/plug/adapters/cowboy/conn.ex
+++ b/lib/plug/adapters/cowboy/conn.ex
@@ -31,7 +31,7 @@ defmodule Plug.Adapters.Cowboy.Conn do
   end
 
   def send_resp(req, status, headers, body) do
-    status = "#{status} #{Plug.Conn.Status.string(status)}"
+    status = Integer.to_string(status) <> " " <> Plug.Conn.Status.reason_phrase(status)
     {:ok, req} = Request.reply(status, headers, body, req)
     {:ok, nil, req}
   end

--- a/lib/plug/adapters/cowboy/conn.ex
+++ b/lib/plug/adapters/cowboy/conn.ex
@@ -31,6 +31,13 @@ defmodule Plug.Adapters.Cowboy.Conn do
   end
 
   def send_resp(req, status, headers, body) do
+    statuses = Application.get_env(:plug, :statuses, %{})
+    status =
+      case Map.get(statuses, status) do
+        nil -> status
+        reason_phrase -> "#{status} #{reason_phrase}"
+      end
+
     {:ok, req} = Request.reply(status, headers, body, req)
     {:ok, nil, req}
   end

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -103,6 +103,34 @@ defmodule Plug.Conn do
       # Each item is emitted as a chunk
       Enum.into(~w(each chunk as a word), conn)
 
+  ## Custom Status Codes
+
+  Plug allows status codes to be overridden or added in order to allow
+  new codes not directly specified by plug or its adapters. Adding or
+  overriding a status code is done in the config file. For example, to
+  override the existing 404 reason phrase ("Not Found" by default)
+  and add a new code for 451, the following config can be used:
+
+      config :plug, :statuses, %{
+        404 => "Actually This Was Found",
+        451 => "Unavailable For Legal Reasons"
+      }
+
+  As this configuration is plug specific, plug will need to be recompiled
+  for the changes to take place using:
+
+      MIX_ENV=prod mix deps.compile plug
+
+  The atoms to be used are inflected from the reason_phrase. With the above
+  configuration, the following will all work:
+
+      put_status(conn, :not_found)                     # 404
+      put_status(conn, :actually_this_was_found)       # 404
+      put_status(conn, :unavailable_for_legal_reasons) # 451
+
+  Even though 404 has been overridden, the `:not_found` atom can still be
+  used to set the status to 404 as well as `:actually_this_was_found`.
+
   """
 
   @type adapter         :: {module, term}

--- a/lib/plug/conn/status.ex
+++ b/lib/plug/conn/status.ex
@@ -113,7 +113,13 @@ defmodule Plug.Conn.Status do
     integer
   end
 
-  for {code, reason_phrase} <- Map.merge(statuses, custom_statuses) do
+  for {code, reason_phrase} <- statuses do
+    atom = reason_phrase_to_atom.(reason_phrase)
+    def code(unquote(atom)), do: unquote(code)
+  end
+
+  # This ensures that both the default and custom statuses will work
+  for {code, reason_phrase} <- custom_statuses do
     atom = reason_phrase_to_atom.(reason_phrase)
     def code(unquote(atom)), do: unquote(code)
   end

--- a/lib/plug/conn/status.ex
+++ b/lib/plug/conn/status.ex
@@ -72,7 +72,7 @@ defmodule Plug.Conn.Status do
   reason_phrase_to_atom = fn reason_phrase ->
     reason_phrase
     |> String.downcase()
-    |> String.replace(~r/[']/, "")
+    |> String.replace("'", "")
     |> String.replace(~r/[^a-z0-9]/, "_")
     |> String.to_atom()
   end
@@ -87,13 +87,13 @@ defmodule Plug.Conn.Status do
   end
 
   custom_status_doc =
-  if custom_statuses != %{} do
-    """
-    ## Custom Status Codes
+    if custom_statuses != %{} do
+      """
+      ## Custom Status Codes
 
-    #{status_map_to_doc.(custom_statuses)}
-    """
-  end
+      #{status_map_to_doc.(custom_statuses)}
+      """
+    end
 
   @doc """
   Returns the status code given an integer or a known atom.
@@ -124,12 +124,22 @@ defmodule Plug.Conn.Status do
     def code(unquote(atom)), do: unquote(code)
   end
 
-  @spec string(integer) :: String.t
-  def string(integer)
+  @spec reason_phrase(integer) :: String.t
+  def reason_phrase(integer)
 
-  for {code, reason_phrase} <- Map.merge(statuses, custom_statuses) do
-    def string(unquote(code)), do: unquote(reason_phrase)
+  for {code, phrase} <- Map.merge(statuses, custom_statuses) do
+    def reason_phrase(unquote(code)), do: unquote(phrase)
   end
 
-  def string(_), do: raise "#TODO: write the error"
+  def reason_phrase(code) do
+    raise ArgumentError, "Unknown status code #{inspect code}\n\n" <>
+      "Custom codes can be defined in the config file, using the code as the key " <>
+      "and the reason phrase as the value. For example:\n\n" <>
+      "    config :plug, :statuses, %{451 => \"Unavailable For Legal Reasons\"}\n\n" <>
+      "Doing this will allow the use of the atom :unavailable_for_legal_reasons " <>
+      "when setting the status code. For example:\n\n" <>
+      "    put_status(conn, :unavailable_for_legal_reasons)\n\n" <>
+      "After defining the config for custom statuses, recompile plug with:\n\n" <>
+      "    MIX_ENV=dev mix deps.compile plug\n"
+  end
 end

--- a/lib/plug/conn/status.ex
+++ b/lib/plug/conn/status.ex
@@ -3,72 +3,97 @@ defmodule Plug.Conn.Status do
   Conveniences for working with status codes.
   """
 
-  statuses = [
-    continue: 100,
-    switching_protocols: 101,
-    processing: 102,
-    ok: 200,
-    created: 201,
-    accepted: 202,
-    non_authoritative_information: 203,
-    no_content: 204,
-    reset_content: 205,
-    partial_content: 206,
-    multi_status: 207,
-    already_reported: 208,
-    instance_manipulation_used: 226,
-    multiple_choices: 300,
-    moved_permanently: 301,
-    found: 302,
-    see_other: 303,
-    not_modified: 304,
-    use_proxy: 305,
-    reserved: 306,
-    temporary_redirect: 307,
-    permanent_redirect: 308,
-    bad_request: 400,
-    unauthorized: 401,
-    payment_required: 402,
-    forbidden: 403,
-    not_found: 404,
-    method_not_allowed: 405,
-    not_acceptable: 406,
-    proxy_authentication_required: 407,
-    request_timeout: 408,
-    conflict: 409,
-    gone: 410,
-    length_required: 411,
-    precondition_failed: 412,
-    request_entity_too_large: 413,
-    request_uri_too_long: 414,
-    unsupported_media_type: 415,
-    requested_range_not_satisfiable: 416,
-    expectation_failed: 417,
-    im_a_teapot: 418,
-    misdirected_request: 421,
-    unprocessable_entity: 422,
-    locked: 423,
-    failed_dependency: 424,
-    upgrade_required: 426,
-    precondition_required: 428,
-    too_many_requests: 429,
-    request_header_fields_too_large: 431,
-    internal_server_error: 500,
-    not_implemented: 501,
-    bad_gateway: 502,
-    service_unavailable: 503,
-    gateway_timeout: 504,
-    http_version_not_supported: 505,
-    variant_also_negotiates: 506,
-    insufficient_storage: 507,
-    loop_detected: 508,
-    not_extended: 510,
-    network_authentication_required: 511
-  ]
+  custom_statuses = Application.get_env(:plug, :statuses, %{})
 
-  doc = Enum.map(statuses, fn {atom, code} ->
-    "  * `#{inspect atom}` - #{code}\n"
-  end)
+  statuses = %{
+    100 => "Continue",
+    101 => "Switching Protocols",
+    102 => "Processing",
+    200 => "OK",
+    201 => "Created",
+    202 => "Accepted",
+    203 => "Non-Authoritative Information",
+    204 => "No Content",
+    205 => "Reset Content",
+    206 => "Partial Content",
+    207 => "Multi-Status",
+    208 => "Already Reported",
+    226 => "IM Used",
+    300 => "Multiple Choices",
+    301 => "Moved Permanently",
+    302 => "Found",
+    303 => "See Other",
+    304 => "Not Modified",
+    305 => "Use Proxy",
+    306 => "Switch Proxy",
+    307 => "Temporary Redirect",
+    308 => "Permanent Redirect",
+    400 => "Bad Request",
+    401 => "Unauthorized",
+    402 => "Payment Required",
+    403 => "Forbidden",
+    404 => "Not Found",
+    405 => "Method Not Allowed",
+    406 => "Not Acceptable",
+    407 => "Proxy Authentication Required",
+    408 => "Request Timeout",
+    409 => "Conflict",
+    410 => "Gone",
+    411 => "Length Required",
+    412 => "Precondition Failed",
+    413 => "Request Entity Too Large",
+    414 => "Request-URI Too Long",
+    415 => "Unsupported Media Type",
+    416 => "Requested Range Not Satisfiable",
+    417 => "Expectation Failed",
+    418 => "I'm a teapot",
+    421 => "Misdirected Request",
+    422 => "Unprocessable Entity",
+    423 => "Locked",
+    424 => "Failed Dependency",
+    425 => "Unordered Collection",
+    426 => "Upgrade Required",
+    428 => "Precondition Required",
+    429 => "Too Many Requests",
+    431 => "Request Header Fields Too Large",
+    500 => "Internal Server Error",
+    501 => "Not Implemented",
+    502 => "Bad Gateway",
+    503 => "Service Unavailable",
+    504 => "Gateway Timeout",
+    505 => "HTTP Version Not Supported",
+    506 => "Variant Also Negotiates",
+    507 => "Insufficient Storage",
+    508 => "Loop Detected",
+    510 => "Not Extended",
+    511 => "Network Authentication Required"
+  }
+
+  reason_phrase_to_atom = fn reason_phrase ->
+    reason_phrase
+    |> String.downcase()
+    |> String.replace(~r/[']/, "")
+    |> String.replace(~r/[^a-z0-9]/, "_")
+    |> String.to_atom()
+  end
+
+  status_map_to_doc = fn statuses ->
+    statuses
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map(fn {code, reason_phrase} ->
+      atom = reason_phrase_to_atom.(reason_phrase)
+      "  * `#{inspect atom}` - #{code}\n"
+    end)
+  end
+
+  custom_status_doc =
+  if custom_statuses != %{} do
+    """
+    ## Custom Status Codes
+
+    #{status_map_to_doc.(custom_statuses)}
+    """
+  end
 
   @doc """
   Returns the status code given an integer or a known atom.
@@ -78,7 +103,8 @@ defmodule Plug.Conn.Status do
   The following status codes can be given as atoms with their
   respective value shown next:
 
-  #{doc}
+  #{status_map_to_doc.(statuses)}
+  #{custom_status_doc}
   """
   @spec code(integer | atom) :: integer
   def code(integer_or_atom)
@@ -87,7 +113,17 @@ defmodule Plug.Conn.Status do
     integer
   end
 
-  for {atom, code} <- statuses do
+  for {code, reason_phrase} <- Map.merge(statuses, custom_statuses) do
+    atom = reason_phrase_to_atom.(reason_phrase)
     def code(unquote(atom)), do: unquote(code)
   end
+
+  @spec string(integer) :: String.t
+  def string(integer)
+
+  for {code, reason_phrase} <- Map.merge(statuses, custom_statuses) do
+    def string(unquote(code)), do: unquote(reason_phrase)
+  end
+
+  def string(_), do: raise "#TODO: write the error"
 end

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -140,7 +140,7 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
 
     Application.put_env(:plug, :statuses, %{451 => "Unavailable For Legal Reasons"})
     Code.compiler_options(ignore_module_conflict: true)
-    Code.load_file(Path.join(__DIR__, "../../../../lib/plug/adapters/cowboy/conn.ex"))
+    Code.load_file(Path.join(__DIR__, "../../../../lib/plug/conn/status.ex"))
 
     assert {451, _headers, ""} = request :get, "/send_451"
 
@@ -156,7 +156,7 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
 
     Application.put_env(:plug, :statuses, %{200 => "Is there a good reason for this?"})
     Code.compiler_options(ignore_module_conflict: true)
-    Code.load_file(Path.join(__DIR__, "../../../../lib/plug/adapters/cowboy/conn.ex"))
+    Code.load_file(Path.join(__DIR__, "../../../../lib/plug/conn/status.ex"))
 
     {:ok, ref} = :hackney.get("http://127.0.0.1:8001/send_200", [], "", async: :once)
     assert_receive({:hackney_response, ^ref, {:status, 200, "Is there a good reason for this?"}})

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -137,7 +137,11 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
 
   test "allows customized statuses based on config" do
     assert {500, _headers, _} = request :get, "/send_451"
+
     Application.put_env(:plug, :statuses, %{451 => "Unavailable For Legal Reasons"})
+    Code.compiler_options(ignore_module_conflict: true)
+    Code.load_file(Path.join(__DIR__, "../../../../lib/plug/adapters/cowboy/conn.ex"))
+
     assert {451, _headers, ""} = request :get, "/send_451"
 
     {:ok, ref} = :hackney.get("http://127.0.0.1:8001/send_451", [], "", async: :once)

--- a/test/plug/conn/status_test.exs
+++ b/test/plug/conn/status_test.exs
@@ -1,0 +1,40 @@
+defmodule Plug.Conn.StatusTest do
+  use ExUnit.Case
+
+  alias Plug.Conn.Status
+
+  test "code for built-in statuses the numeric code" do
+    assert Status.code(:ok) == 200
+    assert Status.code(:non_authoritative_information) == 203
+    assert Status.code(:not_found) == 404
+  end
+
+  test "code for custom status return the numeric code" do
+    assert Status.code(:unavailable_for_legal_reasons) == 451
+  end
+
+  test "code with both a built_in and custom code return the numeric code" do
+    assert Status.code(:im_a_teapot) == 418
+    assert Status.code(:totally_not_a_teapot) == 418
+  end
+
+  test "reason_phrase returns the phrase for built_in statuses" do
+    assert Status.reason_phrase(200) == "OK"
+    assert Status.reason_phrase(203) == "Non-Authoritative Information"
+    assert Status.reason_phrase(404) == "Not Found"
+  end
+
+  test "reason_phrase for custom status return the phrase" do
+    assert Status.reason_phrase(451) == "Unavailable For Legal Reasons"
+  end
+
+  test "reason_phrase with both a built_in and custom status always returns the custom phrase" do
+    assert Status.reason_phrase(418) == "Totally not a teapot"
+  end
+
+  test "reason_phrase with an unknown code raises an error" do
+    assert_raise(ArgumentError, fn ->
+      Status.reason_phrase(999)
+    end)
+  end
+end


### PR DESCRIPTION
The responses can now be customised by modifying the following config
option:

    config :plug, :statuses, %{451 => "Unavailable For Legal Reasons"}

Since Cowboy uses either a fixed list of status codes, or a binary and
Plug only supports using a numeric status code, only the codes supported
by Cowboy can actually be used. Attempting something like:

    send_resp(conn, 451, "")

would error as cowboy does not recognize 451. This now works, as long as
the status is set in the configuration.