### PR TITLE
Allow assigns to be merged in routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * Add `:init_opts` option to forward macro for plug options
   * Add the `:path_params` field to `Plug.Conn` to access path params
     apart from the `params` field
+  * Add `:assigns` option to `Plug.Router` macros to assign values to
+    `conn.assigns` for use in the match
 
 * Bug fixes
   * Keep `body_params` unfetched if the content-type is allowed to

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -145,7 +145,12 @@ defmodule Plug.RouterTest do
       conn |> resp(200, inspect(conn.private))
     end
 
-    forward "/options/forward", to: Forward, private: %{an_option: :a_value}
+    get "/options/assigns", assigns: %{an_option: :a_value} do
+      conn |> resp(200, inspect(conn.assigns))
+    end
+
+    forward "/options/forward", to: Forward, private: %{an_option: :a_value},
+      assigns: %{another_option: :another_value}
 
     plug = SamplePlug
     opts = [foo: :bar]
@@ -393,9 +398,16 @@ defmodule Plug.RouterTest do
     assert conn.resp_body =~ ~s(an_option: :a_value)
   end
 
+  test "assigns route options to assigns conn map" do
+    conn = call(Sample, conn(:get, "/options/assigns"))
+    assert conn.assigns[:an_option] == :a_value
+    assert conn.resp_body =~ ~s(an_option: :a_value)
+  end
+
   test "assigns options on forward" do
     conn = call(Sample, conn(:get, "/options/forward"))
     assert conn.private[:an_option] == :a_value
+    assert conn.assigns[:another_option] == :another_value
     assert conn.resp_body == "forwarded"
   end
 


### PR DESCRIPTION
In exploring the possibility of migrating Phoenix routes back to pure Plug I found there was no `:assigns` option for routes. This PR adds it.

Equivalent to to https://github.com/phoenixframework/phoenix/issues/887