### PR TITLE
Add default implementation for empty :do block Plug.Router definitions

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -371,9 +371,9 @@ defmodule Plug.Router do
   defp compile(method, expr, options, contents) do
     {body, options} =
       cond do
-        b = contents[:do] ->
-          {b, options}
-        options[:do] ->
+        Keyword.has_key?(contents, :do) ->
+          {contents[:do], options}
+        Keyword.has_key?(options, :do) ->
           Keyword.pop(options, :do)
         options[:to] ->
           {to, options} = Keyword.pop(options, :to)

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -94,6 +94,9 @@ defmodule Plug.RouterTest do
       conn |> resp(200, "root")
     end
 
+    get "/bodyless" do
+    end
+
     get "/1/bar" do
       conn |> resp(200, "ok")
     end
@@ -176,6 +179,12 @@ defmodule Plug.RouterTest do
   test "dispatch root" do
     conn = call(Sample, conn(:get, "/"))
     assert conn.resp_body == "root"
+  end
+
+  test "dispatch empty body plug" do
+    assert_raise RuntimeError, fn ->
+      call(Sample, conn(:get, "/bodyless"))
+    end
   end
 
   test "dispatch literal segment" do


### PR DESCRIPTION
Before this change, adding an empty body method definition such as

```
get "/" do
end
```

Would throw "(ArgumentError) expected :do to be given as option" which is
confusing for newbies, this change adds a default implementation for empty body
plugs that returns 204 (No Content).

===

Main motivation for this was I was implementing a simple web api and stumbled
across this weird error "expected :do to be given as an option" which took me
a bit to figure out, since in fact I was actually providing a :do option.

This is a tentative solution as I wanted to get to know the Plug codebase better
anyway. I guess just throwing a specific error such as ":do blocks should always
return a conn" would also be better than the generic catch-all error.

What do you guys think?

Thank you,
HR