### PR TITLE
Make Conn.get_req_header RFC 2616 compliant

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -510,7 +510,8 @@ defmodule Plug.Conn do
   """
   @spec get_req_header(t, binary) :: [binary]
   def get_req_header(%Conn{req_headers: headers}, key) when is_binary(key) do
-    for {k, v} <- headers, k == key, do: v
+    downcased_key = String.downcase(key)
+    for {k, v} <- headers, String.downcase(k) == downcased_key, do: v
   end
 
   @doc """

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -448,6 +448,14 @@ defmodule Plug.ConnTest do
     assert conn.resp_body == "HELLO"
   end
 
+  test "case_insensitive get_req_header/2" do
+    conn = conn(:get, "/")
+    assert get_req_header(conn, "foo") == []
+
+    conn = put_req_header(conn, "foo", "bar")
+    assert get_req_header(conn, "FOO") == ["bar"]
+  end
+
   test "get_req_header/2, put_req_header/3 and delete_req_header/2" do
     conn = conn(:get, "/")
     assert get_req_header(conn, "foo") == []


### PR DESCRIPTION
According to the HTTP spec [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), header field names are case-insensitive.

I also wanted to change the `update_req_header` `delete_req_header` methods, but wanted to discuss if those should be updated.