### PR TITLE
Use Plug.Conn in function and module examples

### DIFF
--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -31,12 +31,14 @@ defmodule Plug do
   Here's an example of a function plug:
 
       def json_header_plug(conn, opts) do
-        conn |> put_resp_content_type("application/json")
+        conn |> Plug.Conn.put_resp_content_type("application/json")
       end
 
   Here's an example of a module plug:
 
       defmodule JSONHeaderPlug do
+        import Plug.Conn
+
         def init(opts) do
           opts
         end


### PR DESCRIPTION
Fixes a minor omission in the Plug examples section, in the interests of clarity/completeness.

* The module example definitely needs to either import or fully reference the `Plug.Conn` module.
* The function example might as well not assume an `import` that isn't actually shown.