### PR TITLE
Conn.Cookies: Support arbitrary cookie attributes

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -806,12 +806,14 @@ defmodule Plug.Conn do
   ## Options
 
     * `:domain` - the domain the cookie applies to
-    * `:max_age` - the cookie max-age, in seconds. Providing a value for this option will set
-      both the _max-age_ and _expires_ cookie attributes
+    * `:max_age` - the cookie max-age, in seconds. Providing a value for this
+      option will set both the _max-age_ and _expires_ cookie attributes
     * `:path` - the path the cookie applies to
     * `:http_only` - when false, the cookie is accessible beyond http
     * `:secure` - if the cookie must be sent only over https. Defaults
       to true when the connection is https
+    * `:extra` - string to append to cookie. Use this to take advantage of
+      non-standard cookie attributes.
 
   """
   @spec put_resp_cookie(t, binary, binary, Keyword.t) :: t

--- a/lib/plug/conn/cookies.ex
+++ b/lib/plug/conn/cookies.ex
@@ -68,6 +68,7 @@ defmodule Plug.Conn.Cookies do
     |> concat_if(opts[:max_age], &encode_max_age(&1, opts))
     |> concat_if(Map.get(opts, :secure, false), "; secure")
     |> concat_if(Map.get(opts, :http_only, true), "; HttpOnly")
+    |> concat_if(opts[:extra], &"; #{&1}")
   end
 
   defp encode_max_age(max_age, opts) do

--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -27,6 +27,7 @@ defmodule Plug.Session do
     * `:path` - see `Plug.Conn.put_resp_cookie/4`;
     * `:secure` - see `Plug.Conn.put_resp_cookie/4`;
     * `:http_only` - see `Plug.Conn.put_resp_cookie/4`;
+    * `:extra` - see `Plug.Conn.put_resp_cookie/4`;
 
   Additional options can be given to the session store, see the store's
   documentation for the options it accepts.
@@ -39,7 +40,7 @@ defmodule Plug.Session do
   alias Plug.Conn
   @behaviour Plug
 
-  @cookie_opts [:domain, :max_age, :path, :secure, :http_only]
+  @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :extra]
 
   def init(opts) do
     store        = Keyword.fetch!(opts, :store) |> convert_store

--- a/test/plug/conn/cookies_test.exs
+++ b/test/plug/conn/cookies_test.exs
@@ -56,4 +56,9 @@ defmodule Plug.Conn.CookiesTest do
     assert encode("foo", %{value: "bar", max_age: 60, universal_time: start}) ==
            "foo=bar; path=/; expires=Sat, 29 Sep 2012 15:33:10 GMT; max-age=60; HttpOnly"
   end
+
+  test "encodes with :extra option" do
+    assert encode("foo", %{value: "bar", extra: "SameSite=Lax"}) ==
+           "foo=bar; path=/; HttpOnly; SameSite=Lax"
+  end
 end

--- a/test/plug/session_test.exs
+++ b/test/plug/session_test.exs
@@ -12,11 +12,11 @@ defmodule Plug.SessionTest do
     assert conn.resp_cookies == %{}
 
     conn = conn(:get, "/") |> fetch_cookies
-    opts = Plug.Session.init(store: ProcessStore, key: "foobar", secure: true, path: "some/path")
+    opts = Plug.Session.init(store: ProcessStore, key: "foobar", secure: true, path: "some/path", extra: "extra")
     conn = Plug.Session.call(conn, opts) |> fetch_session
     conn = put_session(conn, "foo", "bar")
     conn = send_resp(conn, 200, "")
-    assert %{"foobar" => %{value: _, secure: true, path: "some/path"}} = conn.resp_cookies
+    assert %{"foobar" => %{value: _, secure: true, path: "some/path", extra: "extra"}} = conn.resp_cookies
     refute conn.resp_cookies["foobar"] |> Map.has_key?(:http_only)
 
     conn = conn(:get, "/") |> fetch_cookies


### PR DESCRIPTION
This adds support for the [`SameSite`](https://tools.ietf.org/html/draft-west-first-party-cookies) cookie attribute, which controls whether the cookie should be sent along with cross-origin requests. `SameSite=Strict` excludes the cookie from all cross-origin requests whereas `SameSite=Lax` allows the cookie to be sent by links and GET forms.

Not sure what the policy is on browser support. `SameSite` is only supported in Chrome and Opera right now with plans to implement in Firefox. Please close if that's not acceptable. It would be nice to be able to set this attribute for session cookies, though.