### PR TITLE
Test Elixir 1.4.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: elixir
-
+sudo: false
+elixir: 1.4.0
+otp_release: 19.1
 matrix:
   include:
-    - otp_release: 18.3
-      elixir: 1.2.6
-    - otp_release: 18.3
-      elixir: 1.3.1
-    - otp_release: 19.0
-      elixir: 1.3.1
-
-sudo: false
+    - elixir: 1.2.6
+      otp_release: 18.1
 notifications:
   recipients:
     - jose.valim@plataformatec.com.br


### PR DESCRIPTION
I also updated the .travis.yml to match elixir-lang/ex_doc#656 so that only the newest and oldest Elixir/OTP pairs are tested.