### PR TITLE
Make list item indents consistent

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -802,7 +802,7 @@ defmodule Plug.Conn do
 
     * `:domain` - the domain the cookie applies to
     * `:max_age` - the cookie max-age, in seconds. Providing a value for this option will set
-    both the _max-age_ and _expires_ cookie attributes
+      both the _max-age_ and _expires_ cookie attributes
     * `:path` - the path the cookie applies to
     * `:http_only` - when false, the cookie is accessible beyond http
     * `:secure` - if the cookie must be sent only over https. Defaults

--- a/lib/plug/request_id.ex
+++ b/lib/plug/request_id.ex
@@ -23,8 +23,8 @@ defmodule Plug.RequestId do
   ## Options
 
     * `:http_header` - The name of the HTTP *request* header to check for
-    existing request ids. This is also the HTTP *response* header that will be
-    set with the request id. Default value is "x-request-id"
+      existing request ids. This is also the HTTP *response* header that will be
+      set with the request id. Default value is "x-request-id"
 
         plug Plug.RequestId, http_header: "custom-request-id"
   """


### PR DESCRIPTION
Minor documentation improvement. Every list item in the docs indents successive lines, except these two.