### PR TITLE
Updates parsers docs for clearer usage re Ordering

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -73,6 +73,9 @@ defmodule Plug.Parsers do
   the map of params parsed by one of the parsers listed in `:parsers` and
   `:params` set to the result of merging the `:body_params` and `:query_params`.
 
+  It is important that `Plug.Parsers` is ordered prior to the `:dispatch` plug
+  otherwise the matched function will not receive the parsed `Plug.Conn`.
+
   This plug will raise `Plug.Parsers.UnsupportedMediaTypeError` by default if
   the request cannot be parsed by any of the given types and the MIME type has
   not been explicity accepted with the `:pass` option.
@@ -99,6 +102,9 @@ defmodule Plug.Parsers do
       plug Plug.Parsers, parsers: [:urlencoded, :json],
                          pass:  ["text/*"],
                          json_decoder: Poison
+      # ...
+      plug :match
+      plug :dispatch
 
   ## Built-in parsers
 


### PR DESCRIPTION
This just threw me for a loop for a while. I didn't understand that the ordering of my plugs was important. I had my Parsers plug entry after my `plug :dispatch` entry and I couldn't figure out why `body_params` was `Plug.Conn.Unfetched`.

I think this documentation would've helped me get to the bottom of this sooner. Happy to make changes if needed. 