### PR TITLE
Fix timestamp comparison when set/get session

### DIFF
--- a/test/plug/session/ets_test.exs
+++ b/test/plug/session/ets_test.exs
@@ -20,7 +20,7 @@ defmodule Plug.Session.ETSTest do
     assert {"bar", %{bar: :foo}} = ETS.get(%{}, "bar", opts)
     assert [{"foo", %{foo: :bar}, get_timestamp}] = :ets.lookup(@ets_table, "foo")
 
-    assert get_timestamp > put_timestamp
+    assert get_timestamp >= put_timestamp
     assert {nil, %{}} = ETS.get(%{}, "unknown", opts)
   end
 


### PR DESCRIPTION
This change fix the following failure in the unit tests:

```console
$ mix test test/plug/session/ets_test.exs
Compiling 27 files (.ex)
...

  1) test put and get session (Plug.Session.ETSTest)
     test/plug/session/ets_test.exs:12
     Assertion with > failed
     code: get_timestamp > put_timestamp
     lhs:  {1487, 102656, 36000}
     rhs:  {1487, 102656, 36000}
     stacktrace:
       test/plug/session/ets_test.exs:23: (test)



Finished in 0.2 seconds
4 tests, 1 failure

Randomized with seed 765000
```
