### PR TITLE
Raise Plug.AlreadyChunkedError when setting headers on chunked conn

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -237,14 +237,6 @@ defmodule Plug.Conn do
     """
   end
 
-  defmodule AlreadyChunkedError do
-    defexception message: "the response was already sent chunked"
-
-    @moduledoc """
-    Error raised when trying to add a header after a response has had headers set as chunked
-    """
-  end
-
   defmodule CookieOverflowError do
     defexception message: "cookie exceeds maximum size of 4096 bytes"
 
@@ -557,7 +549,7 @@ defmodule Plug.Conn do
   end
 
   def delete_req_header(%Conn{state: :chunked}, _key) do
-    raise AlreadyChunkedError
+    raise AlreadySentError
   end
 
   def delete_req_header(%Conn{req_headers: headers} = conn, key) when
@@ -578,7 +570,7 @@ defmodule Plug.Conn do
   end
 
   def update_req_header(%Conn{state: :chunked}, _key, _initial, _fun) do
-    raise AlreadyChunkedError
+    raise AlreadySentError
   end
 
   def update_req_header(%Conn{} = conn, key, initial, fun) when
@@ -616,7 +608,7 @@ defmodule Plug.Conn do
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
   `:sent`.
 
-  Raises a `Plug.Conn.AlreadyChunkedError` if the connection has already been
+  Raises a `Plug.Conn.AlreadySentError` if the connection has already been
   `:chunked`.
 
   Raises a `Plug.Conn.InvalidHeaderError` if the header value contains control
@@ -628,7 +620,7 @@ defmodule Plug.Conn do
   end
 
   def put_resp_header(%Conn{state: :chunked}, _key, _value) do
-    raise AlreadyChunkedError
+    raise AlreadySentError
   end
 
   def put_resp_header(%Conn{adapter: adapter, resp_headers: headers} = conn, key, value) when
@@ -647,7 +639,7 @@ defmodule Plug.Conn do
   end
 
   def merge_resp_headers(%Conn{state: :chunked}, _headers) do
-    raise AlreadyChunkedError
+    raise AlreadySentError
   end
 
   def merge_resp_headers(conn, headers) when headers == %{} do
@@ -675,7 +667,7 @@ defmodule Plug.Conn do
   end
 
   def delete_resp_header(%Conn{state: :chunked}, _key) do
-    raise AlreadyChunkedError
+    raise AlreadySentError
   end
 
   def delete_resp_header(%Conn{resp_headers: headers} = conn, key) when
@@ -696,7 +688,7 @@ defmodule Plug.Conn do
   end
 
   def update_resp_header(%Conn{state: :chunked}, _key, _initial, _fun) do
-    raise AlreadyChunkedError
+    raise AlreadySentError
   end
 
   def update_resp_header(%Conn{} = conn, key, initial, fun) when
@@ -1029,7 +1021,7 @@ defmodule Plug.Conn do
   defp update_cookies(%Conn{state: :sent}, _fun),
     do: raise AlreadySentError
   defp update_cookies(%Conn{state: :chunked}, _fun),
-    do: raise AlreadyChunkedError
+    do: raise AlreadySentError
   defp update_cookies(%Conn{cookies: %Unfetched{}} = conn, _fun),
     do: conn
   defp update_cookies(%Conn{cookies: cookies} = conn, fun),

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -77,10 +77,11 @@ defmodule Plug.Conn do
       use `Plug.Crypto.KeyGenerator.generate/3` to derive keys from it
     * `state` - the connection state
 
-  The connection state is used to track the connection lifecycle. It starts
-  as `:unset` but is changed to `:set` (via `Plug.Conn.resp/3`) or `:file`
-  (when invoked via `Plug.Conn.send_file/3`). Its final result is
-  `:sent` or `:chunked` depending on the response model.
+  The connection state is used to track the connection lifecycle. It starts as
+  `:unset` but is changed to `:set` (via `Plug.Conn.resp/3`) or `:set_chunked`
+  (used only for `before_send` callbacks by `Plug.conn.send_chunked/2`) or `:file`
+  (when invoked via `Plug.Conn.send_file/3`). Its final result is `:sent` or
+  `:chunked` depending on the response model.
 
   ## Private fields
 
@@ -157,7 +158,7 @@ defmodule Plug.Conn do
   @type scheme          :: :http | :https
   @type secret_key_base :: binary | nil
   @type segments        :: [binary]
-  @type state           :: :unset | :set | :file | :chunked | :sent
+  @type state           :: :unset | :set | :set_chunked | :file | :chunked | :sent
   @type status          :: atom | int_status
 
   @type t :: %__MODULE__{
@@ -236,6 +237,14 @@ defmodule Plug.Conn do
     """
   end
 
+  defmodule AlreadyChunkedError do
+    defexception message: "the response was already sent chunked"
+
+    @moduledoc """
+    Error raised when trying to add a header after a response has had headers set as chunked
+    """
+  end
+
   defmodule CookieOverflowError do
     defexception message: "cookie exceeds maximum size of 4096 bytes"
 
@@ -268,7 +277,7 @@ defmodule Plug.Conn do
 
   alias Plug.Conn
   @already_sent {:plug_conn, :sent}
-  @unsent [:unset, :set]
+  @unsent [:unset, :set, :set_chunked]
 
   @doc """
   Assigns a value to a key in the connection
@@ -445,10 +454,10 @@ defmodule Plug.Conn do
   end
 
   def send_chunked(%Conn{adapter: {adapter, payload}, owner: owner} = conn, status) do
-    conn = run_before_send(%{conn | status: Plug.Conn.Status.code(status), resp_body: nil}, :chunked)
+    conn = run_before_send(%{conn | status: Plug.Conn.Status.code(status), resp_body: nil}, :set_chunked)
     {:ok, body, payload} = adapter.send_chunked(payload, conn.status, conn.resp_headers)
     send owner, @already_sent
-    %{conn | adapter: {adapter, payload}, resp_body: body}
+    %{conn | adapter: {adapter, payload}, state: :chunked, resp_body: body}
   end
 
   @doc """
@@ -547,6 +556,10 @@ defmodule Plug.Conn do
     raise AlreadySentError
   end
 
+  def delete_req_header(%Conn{state: :chunked}, _key) do
+    raise AlreadyChunkedError
+  end
+
   def delete_req_header(%Conn{req_headers: headers} = conn, key) when
       is_binary(key) do
     %{conn | req_headers: List.keydelete(headers, key, 0)}
@@ -562,6 +575,10 @@ defmodule Plug.Conn do
   @spec update_req_header(t, binary, binary, (binary -> binary)) :: t
   def update_req_header(%Conn{state: :sent}, _key, _initial, _fun) do
     raise AlreadySentError
+  end
+
+  def update_req_header(%Conn{state: :chunked}, _key, _initial, _fun) do
+    raise AlreadyChunkedError
   end
 
   def update_req_header(%Conn{} = conn, key, initial, fun) when
@@ -599,12 +616,19 @@ defmodule Plug.Conn do
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
   `:sent`.
 
+  Raises a `Plug.Conn.AlreadyChunkedError` if the connection has already been
+  `:chunked`.
+
   Raises a `Plug.Conn.InvalidHeaderError` if the header value contains control
   feed (\r) or newline (\n) characters.
   """
   @spec put_resp_header(t, binary, binary) :: t
   def put_resp_header(%Conn{state: :sent}, _key, _value) do
     raise AlreadySentError
+  end
+
+  def put_resp_header(%Conn{state: :chunked}, _key, _value) do
+    raise AlreadyChunkedError
   end
 
   def put_resp_header(%Conn{adapter: adapter, resp_headers: headers} = conn, key, value) when
@@ -620,6 +644,10 @@ defmodule Plug.Conn do
   @spec merge_resp_headers(t, Enum.t) :: t
   def merge_resp_headers(%Conn{state: :sent}, _headers) do
     raise AlreadySentError
+  end
+
+  def merge_resp_headers(%Conn{state: :chunked}, _headers) do
+    raise AlreadyChunkedError
   end
 
   def merge_resp_headers(conn, headers) when headers == %{} do
@@ -646,6 +674,10 @@ defmodule Plug.Conn do
     raise AlreadySentError
   end
 
+  def delete_resp_header(%Conn{state: :chunked}, _key) do
+    raise AlreadyChunkedError
+  end
+
   def delete_resp_header(%Conn{resp_headers: headers} = conn, key) when
       is_binary(key) do
     %{conn | resp_headers: List.keydelete(headers, key, 0)}
@@ -661,6 +693,10 @@ defmodule Plug.Conn do
   @spec update_resp_header(t, binary, binary, (binary -> binary)) :: t
   def update_resp_header(%Conn{state: :sent}, _key, _initial, _fun) do
     raise AlreadySentError
+  end
+
+  def update_resp_header(%Conn{state: :chunked}, _key, _initial, _fun) do
+    raise AlreadyChunkedError
   end
 
   def update_resp_header(%Conn{} = conn, key, initial, fun) when
@@ -992,6 +1028,8 @@ defmodule Plug.Conn do
 
   defp update_cookies(%Conn{state: :sent}, _fun),
     do: raise AlreadySentError
+  defp update_cookies(%Conn{state: :chunked}, _fun),
+    do: raise AlreadyChunkedError
   defp update_cookies(%Conn{cookies: %Unfetched{}} = conn, _fun),
     do: conn
   defp update_cookies(%Conn{cookies: cookies} = conn, fun),

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -363,7 +363,7 @@ defmodule Plug.Conn do
   atoms is available in `Plug.Conn.Status`.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent`.
+  `:sent` or `:chunked`.
   """
   @spec put_status(t, status) :: t
   def put_status(%Conn{state: :sent}, _status),
@@ -524,7 +524,7 @@ defmodule Plug.Conn do
   is not lowercase.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent`.
+  `:sent` or `:chunked`.
   """
   @spec put_req_header(t, binary, binary) :: t
   def put_req_header(%Conn{state: :sent}, _key, _value) do
@@ -541,7 +541,7 @@ defmodule Plug.Conn do
   Deletes a request header if present.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent`.
+  `:sent` or `:chunked`.
   """
   @spec delete_req_header(t, binary) :: t
   def delete_req_header(%Conn{state: :sent}, _key) do
@@ -562,7 +562,7 @@ defmodule Plug.Conn do
   value.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent`.
+  `:sent` or `:chunked`.
   """
   @spec update_req_header(t, binary, binary, (binary -> binary)) :: t
   def update_req_header(%Conn{state: :sent}, _key, _initial, _fun) do
@@ -606,10 +606,7 @@ defmodule Plug.Conn do
   is not lowercase.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent`.
-
-  Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:chunked`.
+  `:sent` or `:chunked`.
 
   Raises a `Plug.Conn.InvalidHeaderError` if the header value contains control
   feed (\r) or newline (\n) characters.
@@ -659,7 +656,7 @@ defmodule Plug.Conn do
   Deletes a response header if present.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent`.
+  `:sent` or `:chunked`.
   """
   @spec delete_resp_header(t, binary) :: t
   def delete_resp_header(%Conn{state: :sent}, _key) do
@@ -680,7 +677,7 @@ defmodule Plug.Conn do
   value.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent`.
+  `:sent` or `:chunked`.
   """
   @spec update_resp_header(t, binary, binary, (binary -> binary)) :: t
   def update_resp_header(%Conn{state: :sent}, _key, _initial, _fun) do

--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -45,7 +45,6 @@ defmodule Plug.Logger do
   defp formatted_diff(diff) when diff > 1000, do: [diff |> div(1000) |> Integer.to_string, "ms"]
   defp formatted_diff(diff), do: [Integer.to_string(diff), "µs"]
 
-  defp connection_type(%{state: :chunked}), do: "Chunked"
   defp connection_type(%{state: :set_chunked}), do: "Chunked"
   defp connection_type(_), do: "Sent"
 end

--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -46,5 +46,6 @@ defmodule Plug.Logger do
   defp formatted_diff(diff), do: [Integer.to_string(diff), "µs"]
 
   defp connection_type(%{state: :chunked}), do: "Chunked"
+  defp connection_type(%{state: :set_chunked}), do: "Chunked"
   defp connection_type(_), do: "Sent"
 end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -358,6 +358,13 @@ defmodule Plug.ConnTest do
     end
   end
 
+  test "put_resp_header/3 raises when the conn is chunked" do
+    conn = send_chunked(conn(:get, "/foo"), 200)
+    assert_raise Plug.Conn.AlreadyChunkedError, fn ->
+      put_resp_header(conn, "x-foo", "bar")
+    end
+  end
+
   test "put_resp_header/3 raises when invalid header key given" do
     conn = conn(:get, "/foo")
     assert_raise Plug.Conn.InvalidHeaderError, ~S[header key is not lowercase: "X-Foo"], fn ->
@@ -419,6 +426,13 @@ defmodule Plug.ConnTest do
   test "update_resp_header/4 raises when the conn was already been sent" do
     conn = send_resp(conn(:head, "/foo"), 200, "ok")
     assert_raise Plug.Conn.AlreadySentError, fn ->
+      update_resp_header(conn, "x-foo", "init", &(&1))
+    end
+  end
+
+  test "update_resp_header/4 raises when the conn is chunked" do
+    conn = send_chunked(conn(:get, "/foo"), 200)
+    assert_raise Plug.Conn.AlreadyChunkedError, fn ->
       update_resp_header(conn, "x-foo", "init", &(&1))
     end
   end
@@ -638,6 +652,16 @@ defmodule Plug.ConnTest do
       put_resp_cookie(conn, "foo", "bar")
     end
     assert_raise Plug.Conn.AlreadySentError, fn ->
+      delete_resp_cookie(conn, "foo")
+    end
+  end
+
+  test "put_resp_cookie/4 and delete_resp_cookie/3 raise when the connection is chunked" do
+    conn = send_chunked(conn(:get, "/foo"), 200)
+    assert_raise Plug.Conn.AlreadyChunkedError, fn ->
+      put_resp_cookie(conn, "foo", "bar")
+    end
+    assert_raise Plug.Conn.AlreadyChunkedError, fn ->
       delete_resp_cookie(conn, "foo")
     end
   end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -360,7 +360,7 @@ defmodule Plug.ConnTest do
 
   test "put_resp_header/3 raises when the conn is chunked" do
     conn = send_chunked(conn(:get, "/foo"), 200)
-    assert_raise Plug.Conn.AlreadyChunkedError, fn ->
+    assert_raise Plug.Conn.AlreadySentError, fn ->
       put_resp_header(conn, "x-foo", "bar")
     end
   end
@@ -432,7 +432,7 @@ defmodule Plug.ConnTest do
 
   test "update_resp_header/4 raises when the conn is chunked" do
     conn = send_chunked(conn(:get, "/foo"), 200)
-    assert_raise Plug.Conn.AlreadyChunkedError, fn ->
+    assert_raise Plug.Conn.AlreadySentError, fn ->
       update_resp_header(conn, "x-foo", "init", &(&1))
     end
   end
@@ -658,10 +658,10 @@ defmodule Plug.ConnTest do
 
   test "put_resp_cookie/4 and delete_resp_cookie/3 raise when the connection is chunked" do
     conn = send_chunked(conn(:get, "/foo"), 200)
-    assert_raise Plug.Conn.AlreadyChunkedError, fn ->
+    assert_raise Plug.Conn.AlreadySentError, fn ->
       put_resp_cookie(conn, "foo", "bar")
     end
-    assert_raise Plug.Conn.AlreadyChunkedError, fn ->
+    assert_raise Plug.Conn.AlreadySentError, fn ->
       delete_resp_cookie(conn, "foo")
     end
   end


### PR DESCRIPTION
Hello,

I'm new to elixir and I thought I'd try my hand at contributing. I set out to tackle issue #495. I'm looking for guidance & criticism 😁 

The problem is that you can't modify headers on a chunked response, since you already streamed the headers. Plug will happily allow you to do this, but you won't see the modified headers in the response.

This PR raises a `Plug.AlreadyChunkedError` if you try to set a header or a cookie on a response who's state is `:chunked`

I ran into a slight problem with the response lifecycle. The three ways of sending a response have the following lifecycle:
- `send_resp/3` - `:unset` -> `:set` -> `:sent`
- `send_file/3` - `:unset` -> `:file` -> `:sent`
- `send_chunked/2` - `:unset` -> `:chunked`

The second state is what the `before_send` callbacks get, and the third state is set after sending. In the case of `send_chunked/2` we're overloading the `:chunked` state. It is both the state before we started streaming data to the client, and after we started streaming it.

`before_send` callbacks are free to change response headers, but after we started streaming, we should throw an error when trying to change headers.

To solve this, I had to add an extra state, `:set_chunked`. This is used so that we can error out after sending the first chunk, but `before_send` can still be allowed to change the unsent but chunked response.

As I said, I'm new here, and adding a new state to the lifecycle seems like a non-trivial change to me. Please let me know if there's a better way to solve this, or if you think adding an extra state is going to Break Things.

