### PR TITLE
Do not send empty iodata chunks

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -461,7 +461,7 @@ defmodule Plug.Conn do
   """
   @spec chunk(t, body) :: {:ok, t} | {:error, term} | no_return
   def chunk(%Conn{adapter: {adapter, payload}, state: :chunked} = conn, chunk) do
-    if IO.iodata_length(chunk) == 0 do
+    if iodata_empty?(chunk) do
       {:ok, conn}
     else
       case adapter.chunk(payload, chunk) do
@@ -476,6 +476,11 @@ defmodule Plug.Conn do
     raise ArgumentError, "chunk/2 expects a chunked response. Please ensure " <>
                          "you have called send_chunked/2 before you send a chunk"
   end
+
+  defp iodata_empty?(""), do: true
+  defp iodata_empty?(binary) when is_binary(binary), do: false
+  defp iodata_empty?([]), do: true
+  defp iodata_empty?([hd | tl]), do: iodata_empty?(hd) && iodata_empty?(tl)
 
   @doc """
   Sends a response with the given status and body.

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -461,14 +461,14 @@ defmodule Plug.Conn do
   """
   @spec chunk(t, body) :: {:ok, t} | {:error, term} | no_return
   def chunk(%Conn{adapter: {adapter, payload}, state: :chunked} = conn, chunk) do
-    case IO.iodata_length(chunk) do
-      0 -> {:ok, conn}
-      _ ->
-        case adapter.chunk(payload, chunk) do
-          :ok                  -> {:ok, conn}
-          {:ok, body, payload} -> {:ok, %{conn | resp_body: body, adapter: {adapter, payload}}}
-          {:error, _} = error  -> error
-        end
+    if IO.iodata_length(chunk) == 0 do
+      {:ok, conn}
+    else
+      case adapter.chunk(payload, chunk) do
+        :ok -> {:ok, conn}
+        {:ok, body, payload} -> {:ok, %{conn | resp_body: body, adapter: {adapter, payload}}}
+        {:error, _} = error -> error
+      end
     end
   end
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -460,12 +460,15 @@ defmodule Plug.Conn do
   otherwise `{:error, reason}`.
   """
   @spec chunk(t, body) :: {:ok, t} | {:error, term} | no_return
-  def chunk(%Conn{state: :chunked} = conn, ""), do: {:ok, conn}
   def chunk(%Conn{adapter: {adapter, payload}, state: :chunked} = conn, chunk) do
-    case adapter.chunk(payload, chunk) do
-      :ok                  -> {:ok, conn}
-      {:ok, body, payload} -> {:ok, %{conn | resp_body: body, adapter: {adapter, payload}}}
-      {:error, _} = error  -> error
+    case IO.iodata_length(chunk) do
+      0 -> {:ok, conn}
+      _ ->
+        case adapter.chunk(payload, chunk) do
+          :ok                  -> {:ok, conn}
+          {:ok, body, payload} -> {:ok, %{conn | resp_body: body, adapter: {adapter, payload}}}
+          {:error, _} = error  -> error
+        end
     end
   end
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -478,9 +478,9 @@ defmodule Plug.Conn do
   end
 
   defp iodata_empty?(""), do: true
-  defp iodata_empty?(binary) when is_binary(binary), do: false
   defp iodata_empty?([]), do: true
-  defp iodata_empty?([hd | tl]), do: iodata_empty?(hd) && iodata_empty?(tl)
+  defp iodata_empty?([head | tail]), do: iodata_empty?(head) and iodata_empty?(tail)
+  defp iodata_empty?(_), do: false
 
   @doc """
   Sends a response with the given status and body.

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -870,9 +870,10 @@ defmodule Plug.ConnTest do
       defdelegate send_chunked(state, status, headers), to: Plug.Adapters.Test.Conn
 
       def chunk(payload, chunk) do
-        case IO.iodata_length(chunk) do
-          0 -> flunk "empty chunk #{inspect chunk} was unexpectedly sent"
-          _ -> Plug.Adapters.Test.Conn.chunk(payload, chunk)
+        if IO.iodata_length(chunk) == 0 do
+          flunk "empty chunk #{inspect chunk} was unexpectedly sent"
+        else
+          Plug.Adapters.Test.Conn.chunk(payload, chunk)
         end
       end
     end


### PR DESCRIPTION
This is a followup to #396, which stopped sending blank string
chunks. However, `body` can be any type of iodata, including an
empty list, a list containing a blank string, etc. As such we have
to look at the length of the iodata to determine if it is non-empty.