### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ defmodule MyPlugTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  @opts AppRouter.init([])
+  @opts MyRouter.init([])
 
   test "returns hello world" do
     # Create a test connection
     conn = conn(:get, "/hello")
 
     # Invoke the plug
-    conn = AppRouter.call(conn, @opts)
+    conn = MyRouter.call(conn, @opts)
 
     # Assert the response and status
     assert conn.state == :sent


### PR DESCRIPTION
Use the same `MyRouter` module name on the Testing plugs section.

It mentions "Here is how we can test the router from above", but the name was not the same, it was a bit confusing for me as a new comer. :)