### PR TITLE
Add HSTS 'preload' flag to Plug.SSL options

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -33,6 +33,9 @@ defmodule Plug.SSL do
     * `:rewrite_on` - rewrites the scheme to https based on the given headers
     * `:hsts` - a boolean on enabling HSTS or not, defaults to true.
     * `:expires` - seconds to expires for HSTS, defaults to 31536000 (a year).
+    * `:preload` - a boolean to request inclusion on the HSTS preload list 
+       (for full set of required flags, see: 
+       [Chromium HSTS submission site](https://hstspreload.org)).
     * `:subdomains` - a boolean on including subdomains or not in HSTS,
       defaults to false.
     * `:host` - a new host to redirect to if the request's scheme is `http`,
@@ -81,10 +84,12 @@ defmodule Plug.SSL do
   defp hsts_header(opts) do
     if Keyword.get(opts, :hsts, true) do
       expires    = Keyword.get(opts, :expires, 31_536_000)
+      preload    = Keyword.get(opts, :preload, false)
       subdomains = Keyword.get(opts, :subdomains, false)
 
-      "max-age=#{expires}" <>
-        if(subdomains, do: "; includeSubDomains", else: "")
+      "max-age=#{expires}" 
+        <> if(preload, do: "; preload", else: "")
+        <> if(subdomains, do: "; includeSubDomains", else: "")
     end
   end
 

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -33,8 +33,8 @@ defmodule Plug.SSL do
     * `:rewrite_on` - rewrites the scheme to https based on the given headers
     * `:hsts` - a boolean on enabling HSTS or not, defaults to true.
     * `:expires` - seconds to expires for HSTS, defaults to 31536000 (a year).
-    * `:preload` - a boolean to request inclusion on the HSTS preload list 
-       (for full set of required flags, see: 
+    * `:preload` - a boolean to request inclusion on the HSTS preload list
+       (for full set of required flags, see:
        [Chromium HSTS submission site](https://hstspreload.org)).
     * `:subdomains` - a boolean on including subdomains or not in HSTS,
       defaults to false.
@@ -87,7 +87,7 @@ defmodule Plug.SSL do
       preload    = Keyword.get(opts, :preload, false)
       subdomains = Keyword.get(opts, :subdomains, false)
 
-      "max-age=#{expires}" 
+      "max-age=#{expires}"
         <> if(preload, do: "; preload", else: "")
         <> if(subdomains, do: "; includeSubDomains", else: "")
     end

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -40,6 +40,20 @@ defmodule Plug.SSLTest do
     refute conn.halted
   end
 
+  test "hsts include preload" do
+    conn = call(conn(:get, "https://example.com/"), preload: true)
+    assert get_resp_header(conn, "strict-transport-security") ==
+           ["max-age=31536000; preload"]
+    refute conn.halted
+  end
+
+  test "hsts with multiple flags" do
+    conn = call(conn(:get, "https://example.com/"), preload: true, subdomains: true)
+    assert get_resp_header(conn, "strict-transport-security") ==
+           ["max-age=31536000; preload; includeSubDomains"]
+    refute conn.halted
+  end
+
   test "rewrites conn http to https based on x-forwarded-proto" do
     conn = conn(:get, "http://example.com/")
            |> put_req_header("x-forwarded-proto", "https")


### PR DESCRIPTION
To request inclusion in the HSTS preload list, the HSTS header needs to include the ``preload`` directive. Please see: https://hstspreload.org/

This change adds a default-false flag to `Plug.SSL` options to make this possible, plus documentation and tests.

