### PR TITLE
Add config env to disable header key validation during test

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -544,7 +544,9 @@ defmodule Plug.Conn do
 
   def put_req_header(%Conn{adapter: adapter, req_headers: headers} = conn, key, value) when
       is_binary(key) and is_binary(value) do
-    validate_header_key!(adapter, key)
+    if Application.get_env(:plug, :validate_header_keys_during_test, true) do
+      validate_header_key!(adapter, key)
+    end
     %{conn | req_headers: List.keystore(headers, key, 0, {key, value})}
   end
 
@@ -633,7 +635,9 @@ defmodule Plug.Conn do
 
   def put_resp_header(%Conn{adapter: adapter, resp_headers: headers} = conn, key, value) when
       is_binary(key) and is_binary(value) do
-    validate_header_key!(adapter, key)
+    if Application.get_env(:plug, :validate_header_keys_during_test, true) do
+      validate_header_key!(adapter, key)
+    end
     validate_header_value!(value)
     %{conn | resp_headers: List.keystore(headers, key, 0, {key, value})}
   end

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -544,9 +544,7 @@ defmodule Plug.Conn do
 
   def put_req_header(%Conn{adapter: adapter, req_headers: headers} = conn, key, value) when
       is_binary(key) and is_binary(value) do
-    if Application.get_env(:plug, :validate_header_keys_during_test, true) do
-      validate_header_key!(adapter, key)
-    end
+    validate_header_key_if_test!(adapter, key)
     %{conn | req_headers: List.keystore(headers, key, 0, {key, value})}
   end
 
@@ -635,9 +633,7 @@ defmodule Plug.Conn do
 
   def put_resp_header(%Conn{adapter: adapter, resp_headers: headers} = conn, key, value) when
       is_binary(key) and is_binary(value) do
-    if Application.get_env(:plug, :validate_header_keys_during_test, true) do
-      validate_header_key!(adapter, key)
-    end
+    validate_header_key_if_test!(adapter, key)
     validate_header_value!(value)
     %{conn | resp_headers: List.keystore(headers, key, 0, {key, value})}
   end
@@ -1062,13 +1058,13 @@ defmodule Plug.Conn do
     %{conn | private: private}
   end
 
-  defp validate_header_key!({Plug.Adapters.Test.Conn, _}, key) do
-    unless valid_header_key?(key) do
+  defp validate_header_key_if_test!({Plug.Adapters.Test.Conn, _}, key) do
+    if Application.get_env(:plug, :validate_header_keys_during_test) and not valid_header_key?(key) do
       raise InvalidHeaderError, "header key is not lowercase: " <> inspect(key)
     end
   end
 
-  defp validate_header_key!(_adapter, _key) do
+  defp validate_header_key_if_test!(_adapter, _key) do
     :ok
   end
 

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -11,6 +11,13 @@ defmodule Plug.Test do
 
     * import all the functions from this module
     * import all the functions from the `Plug.Conn` module
+
+  By default, Plug tests checks for invalid header keys, e.g. header keys which
+  include uppercase letters, and raises a `Plug.Conn.InvalidHeaderError` when it finds one.
+  To disable it, set :validate_header_keys_during_test to false on the app config.
+
+      config :plug, :validate_header_keys_during_test, true
+
   """
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Plug.Mixfile do
   # Configuration for the OTP application
   def application do
     [applications: [:crypto, :logger, :mime],
-     mod: {Plug, []}]
+     mod: {Plug, []},
+     env: [validate_header_keys_during_test: true]]
   end
 
   def deps do

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -372,6 +372,7 @@ defmodule Plug.ConnTest do
   end
 
   test "put_resp_header/3 raises when invalid header key given" do
+    Application.put_env(:plug, :validate_header_keys_during_test, true)
     conn = conn(:get, "/foo")
     assert_raise Plug.Conn.InvalidHeaderError, ~S[header key is not lowercase: "X-Foo"], fn ->
       put_resp_header(conn, "X-Foo", "bar")
@@ -382,7 +383,6 @@ defmodule Plug.ConnTest do
     Application.put_env(:plug, :validate_header_keys_during_test, false)
     conn = conn(:get, "/foo")
     put_resp_header(conn, "X-Foo", "bar")
-    Application.delete_env(:plug, :validate_header_keys_during_test)
   end
 
   test "put_resp_header/3 raises when invalid header value given" do
@@ -504,6 +504,7 @@ defmodule Plug.ConnTest do
   end
 
   test "put_req_header/3 raises when invalid header key given" do
+    Application.put_env(:plug, :validate_header_keys_during_test, true)
     conn = conn(:get, "/foo")
     assert_raise Plug.Conn.InvalidHeaderError, ~S[header key is not lowercase: "X-Foo"], fn ->
       put_req_header(conn, "X-Foo", "bar")
@@ -514,7 +515,6 @@ defmodule Plug.ConnTest do
     Application.put_env(:plug, :validate_header_keys_during_test, false)
     conn = conn(:get, "/foo")
     put_req_header(conn, "X-Foo", "bar")
-    Application.delete_env(:plug, :validate_header_keys_during_test)
   end
 
   test "delete_req_header/2" do

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -378,6 +378,13 @@ defmodule Plug.ConnTest do
     end
   end
 
+  test "put_resp_header/3 doesn't raise with invalid header key given when :validate_header_keys_during_test is disabled" do
+    Application.put_env(:plug, :validate_header_keys_during_test, false)
+    conn = conn(:get, "/foo")
+    put_resp_header(conn, "X-Foo", "bar")
+    Application.delete_env(:plug, :validate_header_keys_during_test)
+  end
+
   test "put_resp_header/3 raises when invalid header value given" do
     assert_raise Plug.Conn.InvalidHeaderError, ~S[header value contains control feed (\r) or newline (\n): "value\rBAR"], fn ->
       put_resp_header(conn(:get, "foo"), "x-sample", "value\rBAR")
@@ -501,6 +508,13 @@ defmodule Plug.ConnTest do
     assert_raise Plug.Conn.InvalidHeaderError, ~S[header key is not lowercase: "X-Foo"], fn ->
       put_req_header(conn, "X-Foo", "bar")
     end
+  end
+
+  test "put_req_header/3 doesn't raise with invalid header key given when :validate_header_keys_during_test is disabled" do
+    Application.put_env(:plug, :validate_header_keys_during_test, false)
+    conn = conn(:get, "/foo")
+    put_req_header(conn, "X-Foo", "bar")
+    Application.delete_env(:plug, :validate_header_keys_during_test)
   end
 
   test "delete_req_header/2" do


### PR DESCRIPTION
For issue #542 . 

I  changed the config key to `:validate_header_keys_during_test` to reflect what it actually does. 

I also wasn't very sure where to document the config env, so I put them under the `Plug.Test` module doc since that is where it is relevant. Let me know if it should go somewhere else.