### PR TITLE
Introduce Plug.HTML.html_escape_to_iodata/1

### DIFF
--- a/lib/plug/html.ex
+++ b/lib/plug/html.ex
@@ -4,7 +4,10 @@ defmodule Plug.HTML do
   """
 
   @doc ~S"""
-  Escapes the given HTML.
+  Escapes the given HTML to string.
+
+      iex> Plug.HTML.html_escape("foo")
+      "foo"
 
       iex> Plug.HTML.html_escape("<foo>")
       "&lt;foo&gt;"
@@ -12,8 +15,27 @@ defmodule Plug.HTML do
       iex> Plug.HTML.html_escape("quotes: \" & \'")
       "quotes: &quot; &amp; &#39;"
   """
+  @spec html_escape(String.t) :: String.t
   def html_escape(data) when is_binary(data) do
-    IO.iodata_to_binary(for <<char <- data>>, do: escape_char(char))
+    IO.iodata_to_binary(to_iodata(data, 0, data))
+  end
+
+  @doc ~S"""
+  Escapes the given HTML to iodata.
+
+      iex> Plug.HTML.html_escape_to_iodata("foo")
+      "foo"
+
+      iex> Plug.HTML.html_escape_to_iodata("<foo>")
+      ["&lt;", "foo", "&gt;" | ""]
+
+      iex> Plug.HTML.html_escape_to_iodata("quotes: \" & \'")
+      ["quotes: ", "&quot;", " ", "&amp;", " ", "&#39;" | ""]
+
+  """
+  @spec html_escape_to_iodata(String.t) :: iodata
+  def html_escape_to_iodata(data) when is_binary(data) do
+    to_iodata(data, 0, data)
   end
 
   @compile {:inline, escape_char: 1}
@@ -25,10 +47,29 @@ defmodule Plug.HTML do
     {?", "&quot;"},
     {?', "&#39;"}
   ]
+  @escapable Enum.map(@escapes, &elem(&1, 0))
 
-  Enum.each @escapes, fn {match, insert} ->
-    defp escape_char(unquote(match)), do: unquote(insert)
+  defp to_iodata(<<char, rest::binary>>, len, original) when char in @escapable do
+    escape_char(rest, len, original, char)
   end
 
-  defp escape_char(char), do: char
+  defp to_iodata(<<_, rest::binary>>, len, original) do
+    to_iodata(rest, len + 1, original)
+  end
+
+  defp to_iodata(<<>>, _length, original) do
+    original
+  end
+
+  defp escape_char(<<rest::binary>>, 0, _original, char) do
+    [escape_char(char) | to_iodata(rest, 0, rest)]
+  end
+
+  defp escape_char(<<rest::binary>>, len, original, char) do
+    [binary_part(original, 0, len), escape_char(char) | to_iodata(rest, 0, rest)]
+  end
+
+  for {match, insert} <- @escapes do
+    defp escape_char(unquote(match)), do: unquote(insert)
+  end
 end

--- a/test/plug/html_test.exs
+++ b/test/plug/html_test.exs
@@ -10,4 +10,15 @@ defmodule Plug.HTMlTest do
     assert html_escape("\"quoted\"") == "&quot;quoted&quot;"
     assert html_escape("html's test") == "html&#39;s test"
   end
+
+  test "escapes HTML to iodata" do
+    assert iodata_escape("<script>") == "&lt;script&gt;"
+    assert iodata_escape("html&company") == "html&amp;company"
+    assert iodata_escape("\"quoted\"") == "&quot;quoted&quot;"
+    assert iodata_escape("html's test") == "html&#39;s test"
+  end
+
+  defp iodata_escape(data) do
+    data |> Plug.HTML.html_escape_to_iodata |> IO.iodata_to_binary
+  end
 end


### PR DESCRIPTION
The implementation tries to keep as much of the original string as possible,
splitting only when an escapable character is encountered. This means far fewer
allocations are required and on clean input (that does not need escaping)
means no allocations are performed.
Also the raw iodata is exposed for uses where iodata is accepted anyways,
e.g. in Phoenix.HTML.Safe.

[Benchmarks]([1]) show the new implementation is 1.5 to 9 times faster depending
on input.

escape_char/4 is not inlined and has an empty check for a binary, since
that allows the io_iodata function to be subjected to binary matching
optimisations.

[1]: https://gist.github.com/michalmuskala/1fd844ca83360e18d796131ca41427fa