### PR TITLE
Clarify session store types

### DIFF
--- a/lib/plug/session/store.ex
+++ b/lib/plug/session/store.ex
@@ -2,8 +2,19 @@ defmodule Plug.Session.Store do
   @moduledoc """
   Specification for session stores.
   """
+  
+  @typedoc """
+  The internal reference to the session in the store.
+  """
   @type sid :: term | nil
+  @typedoc """
+  The cookie value that will encoded in cookie headers.
+  """
   @type cookie :: binary
+  @typedoc """
+  The session contents, the final data to be stored after it has been built
+  with `Plug.Conn.put_session/3` and the other session manipulating functions.
+  """
   @type session :: map
 
   @doc """

--- a/lib/plug/session/store.ex
+++ b/lib/plug/session/store.ex
@@ -2,16 +2,18 @@ defmodule Plug.Session.Store do
   @moduledoc """
   Specification for session stores.
   """
-  
+
   @typedoc """
   The internal reference to the session in the store.
   """
   @type sid :: term | nil
+
   @typedoc """
   The cookie value that will be sent in cookie headers. This value should be
   base64 encoded to avoid security issues.
   """
   @type cookie :: binary
+
   @typedoc """
   The session contents, the final data to be stored after it has been built
   with `Plug.Conn.put_session/3` and the other session manipulating functions.

--- a/lib/plug/session/store.ex
+++ b/lib/plug/session/store.ex
@@ -8,7 +8,7 @@ defmodule Plug.Session.Store do
   """
   @type sid :: term | nil
   @typedoc """
-  The cookie value that will encoded in cookie headers.
+  The cookie value that will be sent in cookie headers.
   """
   @type cookie :: binary
   @typedoc """

--- a/lib/plug/session/store.ex
+++ b/lib/plug/session/store.ex
@@ -8,7 +8,8 @@ defmodule Plug.Session.Store do
   """
   @type sid :: term | nil
   @typedoc """
-  The cookie value that will be sent in cookie headers.
+  The cookie value that will be sent in cookie headers. This value should be
+  base64 encoded to avoid security issues.
   """
   @type cookie :: binary
   @typedoc """


### PR DESCRIPTION
Should `cookie` be base64 encoded or does plug handle that for us?