### PR TITLE
Plug.Upload.path() generating a reliably random name

### DIFF
--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -97,9 +97,9 @@ defmodule Plug.Upload do
   end
 
   defp path(prefix, tmp) do
-    {_mega, sec, micro} = :os.timestamp
+    sec = :os.system_time(:seconds)
     scheduler_id = :erlang.system_info(:scheduler_id)
-    tmp <> "/" <> prefix <> "-" <> i(sec) <> "-" <> i(micro) <> "-" <> i(scheduler_id)
+    tmp <> "/" <> prefix <> "-" <> i(sec) <> "-" <> i(:rand.uniform(1000000)) <> "-" <> i(scheduler_id)
   end
 
   @compile {:inline, i: 1}

--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -99,7 +99,7 @@ defmodule Plug.Upload do
   defp path(prefix, tmp) do
     sec = :os.system_time(:seconds)
     scheduler_id = :erlang.system_info(:scheduler_id)
-    tmp <> "/" <> prefix <> "-" <> i(sec) <> "-" <> i(:rand.uniform(1000000)) <> "-" <> i(scheduler_id)
+    tmp <> "/" <> prefix <> "-" <> i(sec) <> "-" <> i(:rand.uniform(1_000_000)) <> "-" <> i(scheduler_id)
   end
 
   @compile {:inline, i: 1}

--- a/test/plug/upload_test.exs
+++ b/test/plug/upload_test.exs
@@ -1,6 +1,30 @@
 defmodule Plug.UploadTest do
   use ExUnit.Case, async: true
 
+  defp spawn_lots_of_temporary_files(_stop_time, 0), do: :ok
+  defp spawn_lots_of_temporary_files(stop_time, reps) do
+    if :os.system_time(:milli_seconds) < stop_time do
+      {pid, ref} = spawn_monitor fn ->
+        {:ok, _} = Plug.Upload.random_file("sample")
+      end
+      spawn_lots_of_temporary_files(stop_time, reps - 1)
+
+      :ok =
+      receive do
+        {:DOWN, ^ref, :process, ^pid, :normal} -> :ok
+      after
+	20_000 -> :timed_out
+      end
+    end
+  end
+
+  test "can create lots of temporary files in a short period of time" do
+    # this is necessary for windoes which does not give us microsecond resolution
+    # do it in spawned processes to take advantage of auto-cleanup
+    # loop for at least 50 milli seconds, or 100000 iterations
+    spawn_lots_of_temporary_files(:os.system_time(:milli_seconds) + 50, 100000)
+  end
+
   test "removes the random file on process death" do
     parent = self()
 

--- a/test/plug/upload_test.exs
+++ b/test/plug/upload_test.exs
@@ -13,7 +13,7 @@ defmodule Plug.UploadTest do
       receive do
         {:DOWN, ^ref, :process, ^pid, :normal} -> :ok
       after
-	20_000 -> :timed_out
+        20_000 -> :timed_out
       end
     end
   end
@@ -22,7 +22,7 @@ defmodule Plug.UploadTest do
     # this is necessary for windoes which does not give us microsecond resolution
     # do it in spawned processes to take advantage of auto-cleanup
     # loop for at least 50 milli seconds, or 100000 iterations
-    spawn_lots_of_temporary_files(:os.system_time(:milli_seconds) + 50, 100000)
+    spawn_lots_of_temporary_files(:os.system_time(:milli_seconds) + 50, 100_000)
   end
 
   test "removes the random file on process death" do


### PR DESCRIPTION
There is a problem with the random filename logic in Plug when run on Windows, because :os.timestamp does not give microsecond resolution.

On windows, Typically:

iex(1)> IO.inspect :os.timestamp; IO.inspect :os.timestamp
{1496, 22882, 547000}
{1496, 22882, 547000}

And as there are only 10 reties in Plug.Upload.random_file, (which get exhausted within 1 millisecond) it sometimes results in: (Plug.UploadError) tried 10 times to create an uploaded file at C:\Windows\TEMP/plug-1495 but failed. Set PLUG_TMPDIR to a directory with write permission                                                                               

The solution seems to be just to use a random number in place of the microseconds