### PR TITLE
Add `:set_file` state to Plug.Conn

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -158,7 +158,7 @@ defmodule Plug.Conn do
   @type scheme          :: :http | :https
   @type secret_key_base :: binary | nil
   @type segments        :: [binary]
-  @type state           :: :unset | :set | :set_chunked | :file | :chunked | :sent
+  @type state           :: :unset | :set | :set_chunked | :set_file | :file | :chunked | :sent
   @type status          :: atom | int_status
 
   @type t :: %__MODULE__{
@@ -269,7 +269,7 @@ defmodule Plug.Conn do
 
   alias Plug.Conn
   @already_sent {:plug_conn, :sent}
-  @unsent [:unset, :set, :set_chunked]
+  @unsent [:unset, :set, :set_chunked, :set_file]
 
   @doc """
   Assigns a value to a key in the connection
@@ -429,10 +429,10 @@ defmodule Plug.Conn do
       raise ArgumentError, "cannot send_file/5 with null byte"
     end
 
-    conn = run_before_send(%{conn | status: Plug.Conn.Status.code(status), resp_body: nil}, :file)
+    conn = run_before_send(%{conn | status: Plug.Conn.Status.code(status), resp_body: nil}, :set_file)
     {:ok, body, payload} = adapter.send_file(payload, conn.status, conn.resp_headers, file, offset, length)
     send owner, @already_sent
-    %{conn | adapter: {adapter, payload}, state: :sent, resp_body: body}
+    %{conn | adapter: {adapter, payload}, state: :file, resp_body: body}
   end
 
   @doc """

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -157,7 +157,7 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
 
   def send_file(conn) do
     conn = send_file(conn, 200, __ENV__.file)
-    assert conn.state == :sent
+    assert conn.state == :file
     assert conn.resp_body == nil
     conn
   end


### PR DESCRIPTION
Using `get_csrf_token/0` and `send_file/3` in the same action is raising
Plug.Conn.AlreadySentError errors. I tracked it down to the before_send
callback that Plug.CSRFProtection registers to put the token into the
session. `send_file/3` was setting the connection status to `:file`,
which was considered "sent" by `put_session/3`.

I added a separate `:set_file` state to be consistent with
`:set_chunked`. I'm unsure of how changing the final state to `:file`
will affect things, so it might be a better option to just add `:file`
to `@unsent`.