### PR TITLE
Add plug_headers to Plug Exceptions

### DIFF
--- a/lib/plug/error_handler.ex
+++ b/lib/plug/error_handler.ex
@@ -91,6 +91,7 @@ defmodule Plug.ErrorHandler do
         normalized_reason = Exception.normalize(kind, wrapped_reason, stack)
         conn
         |> Plug.Conn.put_status(status(kind, normalized_reason))
+        |> Plug.Conn.merge_resp_headers(headers(kind, normalized_reason))
         |> handle_errors.(%{kind: kind, reason: normalized_reason, stack: stack})
     end
 
@@ -100,4 +101,8 @@ defmodule Plug.ErrorHandler do
   defp status(:error, error),  do: Plug.Exception.status(error)
   defp status(:throw, _throw), do: 500
   defp status(:exit, _exit),   do: 500
+
+  defp headers(:error, error), do: Plug.Exception.headers(error)
+  defp headers(:throw, _throw), do: []
+  defp headers(:exit, _exit),   do: []
 end

--- a/lib/plug/exceptions.ex
+++ b/lib/plug/exceptions.ex
@@ -3,11 +3,12 @@
 
 defprotocol Plug.Exception do
   @moduledoc """
-  A protocol that extends exceptions to be status-code aware.
+  A protocol that extends exceptions to be status-code and headers aware.
 
   By default, it looks for an implementation of the protocol,
   otherwise checks if the exception has the `:plug_status` field
   or simply returns 500.
+  It also checks for the `:plug_headers` field for additional headers.
   """
 
   @fallback_to_any true
@@ -17,11 +18,20 @@ defprotocol Plug.Exception do
   """
   @spec status(t) :: Plug.Conn.status
   def status(exception)
+
+  @doc """
+  Receives an exception and returns its HTTP headers.
+  """
+  @spec headers(t) :: Keyword.t
+  def headers(exception)
 end
 
 defimpl Plug.Exception, for: Any do
   def status(%{plug_status: status}) when is_integer(status), do: status
   def status(_), do: 500
+
+  def headers(%{plug_headers: headers}) when is_list(headers), do: headers
+  def headers(_), do: []
 end
 
 defmodule Plug.BadRequestError do


### PR DESCRIPTION
It should fix #447 (though it's been closed but I do think it'd be really useful).

I didn't add tests yet, I guess I should add them in `error_handler_test.exs` but I'm not really sure whether I should add another test or just a new assert and add another route to `call/2`... If someone could help me with this it'd be great 😃 