### PR TITLE
Improve new dev experience when 

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -191,7 +191,7 @@ defmodule Plug.Conn do
               state:           state,
               status:          int_status}
 
-  defstruct adapter:         {Plug.Conn, nil},
+  defstruct adapter:         {Plug.MissingAdapter, nil},
             assigns:         %{},
             before_send:     [],
             body_params:     %Unfetched{aspect: :body_params},

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -933,4 +933,10 @@ defmodule Plug.ConnTest do
     assert {:ok, conn} == Plug.Conn.chunk(conn, [[]])
     assert {:ok, conn} == Plug.Conn.chunk(conn, [["", ""]])
   end
+
+  test "default adapter doesn't cause confusing errors for newbies" do
+    assert_raise UndefinedFunctionError, ~r/Plug\.MissingAdapter\.send_resp\/4/, fn ->
+      Conn.send_resp(%Plug.Conn{}, 200, "Hello World")
+    end
+  end
 end


### PR DESCRIPTION
In starting to play with Plug, I ran into a newbie issue that I thought could potentially use some improved error messaging

```elixir
defmodule PlugExample do
  import Plug.Conn

  def init(options), do: options

  def call(conn, _opts) do
    conn
    |> put_resp_content_type("text/plain")
    |> send_resp(200, "Hello world\n")
  end
end
```

And calling via:
```
PlugExample.call(%Plug.Conn{}, {})
```

```
** (UndefinedFunctionError) function Plug.Conn.send_resp/4 is
undefined or private. Did you mean one of:

           * send_resp/1
           * send_resp/3
stacktrace:
       (plug) Plug.Conn.send_resp(nil, 200, [{"cache-control", "max-age=0, private, must-revalidate"}, {"content-type", "text/plain; charset=utf-8"}], "Hello world\n")
       (plug) lib/plug/conn.ex:393: Plug.Conn.send_resp/1
       test/plug_example_test.exs:6: (test)
```

I got super-confused because I thought this meant I didn't understand `|>` properly. Reading the stacktrace got me to the bottom of it: `Plug.Conn`'s default adapter is `Plug.Conn` itself.

And in many situations where a `Plug.Conn`'s `adapter` gets used, the default adapter (`Plug.Conn` itself) does not support the necessary arities. For example: `send_resp/4`, `send_file/6`, and `send_chunked/3`, `read_req_body/2`. `chunk/2` has the right arity, but raises.

An alternative implementation would provide all of these functions in `Plug.Conn`, raising `ArgumentError` with a nice error message.

I'm skeptical about whether there is a "good" approach here, but I thought it'd at least be worth discussing whether `Plug.Conn` should really be the default, since it doesn't support much of the expected API.